### PR TITLE
chore(web): lint findings to zero errors + CI lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit
 
+      # Errors fail outright. Warnings are ratcheted: the cap is the current
+      # count of accepted warnings (React-Compiler hooks-rule findings demoted
+      # in eslint.config.mjs + exhaustive-deps) — when you fix warnings, lower
+      # the cap to match; never raise it.
+      - name: Lint
+        run: npm run lint -- --max-warnings 163
+
       - name: Tests
         run: npm test
 

--- a/src/Web/autopilot-monitor-web/app/admin/AdminPageSections.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/AdminPageSections.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { usePageSections } from "../../hooks/usePageSections";
 import { PageSectionItem } from "../../contexts/SidebarContext";
+import { route } from "../../lib/routes";
 import {
   GearIcon,
   NoSymbolIcon,
@@ -47,29 +48,29 @@ function GlobeIcon({ className = "w-5 h-5" }: { className?: string }) {
 export function AdminPageSections() {
   const items: PageSectionItem[] = useMemo(() => [
     // Tenants
-    { id: "management", label: "Tenant Management", href: "/admin/tenants/management", group: "Tenants", groupIcon: <BuildingOfficeIcon /> },
-    { id: "config-report", label: "Config Report", href: "/admin/tenants/config-report", group: "Tenants" },
+    { id: "management", label: "Tenant Management", href: route("/admin/tenants/management"), group: "Tenants", groupIcon: <BuildingOfficeIcon /> },
+    { id: "config-report", label: "Config Report", href: route("/admin/tenants/config-report"), group: "Tenants" },
 
     // Metrics
-    { id: "platform-metrics", label: "Platform Metrics", href: "/admin/metrics/platform-metrics", group: "Metrics", groupIcon: <ChartBarIcon /> },
-    { id: "usage", label: "Platform Usage", href: "/admin/metrics/usage", group: "Metrics" },
-    { id: "mcp-usage", label: "MCP Usage", href: "/admin/metrics/mcp-usage", group: "Metrics" },
+    { id: "platform-metrics", label: "Platform Metrics", href: route("/admin/metrics/platform-metrics"), group: "Metrics", groupIcon: <ChartBarIcon /> },
+    { id: "usage", label: "Platform Usage", href: route("/admin/metrics/usage"), group: "Metrics" },
+    { id: "mcp-usage", label: "MCP Usage", href: route("/admin/metrics/mcp-usage"), group: "Metrics" },
 
     // Reports
-    { id: "session-reports", label: "Session Reports", href: "/admin/reports/session-reports", group: "Reports", groupIcon: <DocumentTextIcon /> },
-    { id: "user-feedback", label: "User Feedback", href: "/admin/reports/user-feedback", group: "Reports" },
-    { id: "session-export", label: "Session Export", href: "/admin/reports/session-export", group: "Reports" },
+    { id: "session-reports", label: "Session Reports", href: route("/admin/reports/session-reports"), group: "Reports", groupIcon: <DocumentTextIcon /> },
+    { id: "user-feedback", label: "User Feedback", href: route("/admin/reports/user-feedback"), group: "Reports" },
+    { id: "session-export", label: "Session Export", href: route("/admin/reports/session-export"), group: "Reports" },
 
     // Security
-    { id: "device-block", label: "Device Block", href: "/admin/security/device-block", group: "Security", groupIcon: <ShieldCheckIcon /> },
-    { id: "version-block", label: "Version Block", href: "/admin/security/version-block", group: "Security" },
-    { id: "vulnerability-data", label: "Vulnerability Data", href: "/admin/security/vulnerability-data", group: "Security" },
+    { id: "device-block", label: "Device Block", href: route("/admin/security/device-block"), group: "Security", groupIcon: <ShieldCheckIcon /> },
+    { id: "version-block", label: "Version Block", href: route("/admin/security/version-block"), group: "Security" },
+    { id: "vulnerability-data", label: "Vulnerability Data", href: route("/admin/security/vulnerability-data"), group: "Security" },
 
     // Settings
-    { id: "global", label: "Global Settings", href: "/admin/settings/global", group: "Settings", groupIcon: <GearIcon /> },
-    { id: "diagnostics-log-paths", label: "Diagnostics Log Paths", href: "/admin/settings/diagnostics-log-paths", group: "Settings" },
-    { id: "config-reseed", label: "Config Reseed", href: "/admin/settings/config-reseed", group: "Settings" },
-    { id: "usage-plans", label: "Usage Plans", href: "/admin/settings/usage-plans", group: "Settings" },
+    { id: "global", label: "Global Settings", href: route("/admin/settings/global"), group: "Settings", groupIcon: <GearIcon /> },
+    { id: "diagnostics-log-paths", label: "Diagnostics Log Paths", href: route("/admin/settings/diagnostics-log-paths"), group: "Settings" },
+    { id: "config-reseed", label: "Config Reseed", href: route("/admin/settings/config-reseed"), group: "Settings" },
+    { id: "usage-plans", label: "Usage Plans", href: route("/admin/settings/usage-plans"), group: "Settings" },
 
     // Ops (single page)
     { id: "ops", label: "Maintenance", href: "/admin/ops", group: "Ops", groupIcon: <WrenchIcon /> },

--- a/src/Web/autopilot-monitor-web/app/admin/AdminPageSections.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/AdminPageSections.tsx
@@ -6,21 +6,11 @@ import { PageSectionItem } from "../../contexts/SidebarContext";
 import { route } from "../../lib/routes";
 import {
   GearIcon,
-  NoSymbolIcon,
   DocumentTextIcon,
   ChartBarIcon,
   BuildingOfficeIcon,
   ShieldCheckIcon,
 } from "../../lib/sidebarIcons";
-
-// Inline icon (same as MetricsSidebar had)
-function TrendingUpIcon({ className = "w-5 h-5" }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
-    </svg>
-  );
-}
 
 // Inline icon for Ops (wrench)
 function WrenchIcon({ className = "w-5 h-5" }: { className?: string }) {

--- a/src/Web/autopilot-monitor-web/app/admin/backups/components/RestoreRowDiffModal.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/backups/components/RestoreRowDiffModal.tsx
@@ -90,7 +90,7 @@ export function RestoreRowDiffModal({
                 This is an <strong>authentication / authorization</strong> table
                 (<code className="font-mono">GlobalAdmins</code>, <code className="font-mono">TenantAdmins</code>,{" "}
                 <code className="font-mono">McpUsers</code>). Restoring this row will overwrite the live{" "}
-                <code className="font-mono">IsEnabled</code> flag — confirm that the backup row's enable/disable
+                <code className="font-mono">IsEnabled</code> flag — confirm that the backup row&apos;s enable/disable
                 state is what you intend.
               </div>
             </div>

--- a/src/Web/autopilot-monitor-web/app/admin/components/OpsAlertRulesSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/components/OpsAlertRulesSection.tsx
@@ -232,14 +232,6 @@ export function OpsAlertRulesSection({
   const enabledRulesCount = rules.filter(r => r.enabled).length;
   const enabledProviders = [telegramEnabled, teamsEnabled, slackEnabled].filter(Boolean).length;
 
-  // Get category for a given event type
-  const getCategoryForEvent = (eventType: string): string => {
-    for (const [cat, types] of Object.entries(OPS_EVENT_TYPES)) {
-      if (types.includes(eventType)) return cat;
-    }
-    return "Unknown";
-  };
-
   return (
     <div className="space-y-6">
       {/* Alert Rules */}

--- a/src/Web/autopilot-monitor-web/app/admin/components/OpsEventsSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/components/OpsEventsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { sessionUrl } from "@/lib/routes";
+import { sessionUrl, deviceBlockUrl } from "@/lib/routes";
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { api } from "@/lib/api";
@@ -558,7 +558,6 @@ export function OpsEventsSection({
                 const sessionId = extractSessionId(selectedEvent.details);
                 if (!sessionId) return null;
                 const reason = buildAutoReason(selectedEvent.eventType, sessionId);
-                const baseHref = `/admin/security/device-block?sessionId=${encodeURIComponent(sessionId)}&reason=${encodeURIComponent(reason)}`;
                 return (
                   <div className="mt-5 pt-4 border-t border-gray-200 dark:border-gray-700">
                     <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
@@ -574,14 +573,14 @@ export function OpsEventsSection({
                         View session
                       </Link>
                       <Link
-                        href={`${baseHref}&action=Block`}
+                        href={deviceBlockUrl(sessionId, reason, "Block")}
                         onClick={() => setSelectedEvent(null)}
                         className="inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium bg-orange-100 text-orange-800 hover:bg-orange-200 dark:bg-orange-900/40 dark:text-orange-200 dark:hover:bg-orange-900/60 border border-orange-300 dark:border-orange-700"
                       >
                         Block this device
                       </Link>
                       <Link
-                        href={`${baseHref}&action=Kill`}
+                        href={deviceBlockUrl(sessionId, reason, "Kill")}
                         onClick={() => setSelectedEvent(null)}
                         className="inline-flex items-center px-3 py-1.5 rounded-md text-xs font-medium bg-red-700 text-white hover:bg-red-800 dark:bg-red-700 dark:hover:bg-red-800"
                       >

--- a/src/Web/autopilot-monitor-web/app/admin/components/TenantManagementSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/components/TenantManagementSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { api } from "@/lib/api";
 import { authenticatedFetch, TokenExpiredError } from "@/lib/authenticatedFetch";

--- a/src/Web/autopilot-monitor-web/app/admin/metrics/sections/SectionAgentMetrics.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/metrics/sections/SectionAgentMetrics.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
 import { api } from '@/lib/api';
 import TruncatedLabel from '@/components/TruncatedLabel';
 import { useAuth } from '../../../../contexts/AuthContext';
@@ -138,9 +137,7 @@ function pN(values: number[], percentile: number): number {
 // ── Component ──────────────────────────────────────────────────────────────────
 
 export function SectionAgentMetrics() {
-  const router = useRouter();
-
-  const { getAccessToken, user } = useAuth();
+  const { getAccessToken } = useAuth();
   const { addNotification } = useNotifications();
 
   const [loading, setLoading] = useState(true);
@@ -845,8 +842,6 @@ function StatCard({ label, value, detail, color }: { label: string; value: strin
 function FootprintBadge({
   value,
   thresholds,
-  unit,
-  formatFn,
 }: {
   value: number;
   thresholds: [number, number, number];

--- a/src/Web/autopilot-monitor-web/app/admin/ops/session-cleanup/components/RestoreBrowserTab.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/ops/session-cleanup/components/RestoreBrowserTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api } from "@/lib/api";
 import { authenticatedFetch, TokenExpiredError } from "@/lib/authenticatedFetch";
 import { useAdminConfig } from "../../../AdminConfigContext";

--- a/src/Web/autopilot-monitor-web/app/admin/ops/session-cleanup/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/ops/session-cleanup/page.tsx
@@ -139,7 +139,6 @@ function TabButton({
 function InFlightTab({
   getAccessToken,
   setError,
-  setSuccessMessage,
 }: {
   getAccessToken: (forceRefresh?: boolean) => Promise<string | null>;
   setError: (error: string | null) => void;

--- a/src/Web/autopilot-monitor-web/app/admin/reports/[section]/SectionClient.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/reports/[section]/SectionClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { notFound } from "next/navigation";
-import { REPORTS_NAV_SECTIONS, type ReportsSectionId } from "../reportsNavSections";
+import { type ReportsSectionId } from "../reportsNavSections";
 import { SectionSessionReports } from "../sections/SectionSessionReports";
 import { SectionDistressReports } from "../sections/SectionDistressReports";
 import { SectionUserFeedback } from "../sections/SectionUserFeedback";

--- a/src/Web/autopilot-monitor-web/app/admin/security/[section]/SectionClient.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/security/[section]/SectionClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { notFound } from "next/navigation";
-import { SECURITY_NAV_SECTIONS, type SecuritySectionId } from "../securityNavSections";
+import { type SecuritySectionId } from "../securityNavSections";
 import { SectionDeviceBlock } from "../sections/SectionDeviceBlock";
 import { SectionVersionBlock } from "../sections/SectionVersionBlock";
 import { SectionVulnerabilityData } from "../sections/SectionVulnerabilityData";

--- a/src/Web/autopilot-monitor-web/app/admin/tenants/sections/SectionTenantConfigReport.tsx
+++ b/src/Web/autopilot-monitor-web/app/admin/tenants/sections/SectionTenantConfigReport.tsx
@@ -426,8 +426,6 @@ export function SectionTenantConfigReport() {
       })()
     : [];
 
-  const selectedTenant = tenants.find((t) => t.tenantId === selectedTenantId);
-
   return (
     <div className="max-w-5xl mx-auto px-4 py-8">
       {/* Header */}

--- a/src/Web/autopilot-monitor-web/app/analyze-rules/components/TemplateConfigModal.tsx
+++ b/src/Web/autopilot-monitor-web/app/analyze-rules/components/TemplateConfigModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { AnalyzeRule, TemplateVariable } from "../types";
+import { AnalyzeRule } from "../types";
 
 interface TemplateConfigModalProps {
   rule: AnalyzeRule;

--- a/src/Web/autopilot-monitor-web/app/analyze-rules/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/analyze-rules/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { ProtectedRoute } from "../../components/ProtectedRoute";
 import { useAuth } from "../../contexts/AuthContext";
 import { api } from "@/lib/api";
@@ -25,8 +23,6 @@ import TemplateConfigModal from "./components/TemplateConfigModal";
 import { DOCS_URL } from "@/utils/config";
 
 export default function AnalyzeRulesPage() {
-  const router = useRouter();
-
   const { user, getAccessToken } = useAuth();
 
   const { successMessage, error, showSuccess, showError } = useNotificationMessages();

--- a/src/Web/autopilot-monitor-web/app/apps/detail/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/apps/detail/page.tsx
@@ -376,11 +376,6 @@ function AppDetailContent() {
     return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
   }
 
-  const failureCodeBarColor = (row: Record<string, unknown>): string => {
-    const c = Number(row.count);
-    return c >= 5 ? chartColors.danger : c >= 2 ? chartColors.warning : chartColors.muted;
-  };
-
   return (
     <ProtectedRoute>
       <div className="min-h-screen bg-gray-50">

--- a/src/Web/autopilot-monitor-web/app/audit/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/audit/page.tsx
@@ -2,7 +2,6 @@
 
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { TableSkeleton } from '@/components/skeletons/TableSkeleton';
-import { useRouter } from 'next/navigation';
 import { useAuth } from '../../contexts/AuthContext';
 import { useNotifications } from '../../contexts/NotificationContext';
 import { ProtectedRoute } from '../../components/ProtectedRoute';
@@ -63,8 +62,6 @@ function dateInputToIsoEnd(value: string): string {
 }
 
 export default function AuditPage() {
-  const router = useRouter();
-
   const { getAccessToken } = useAuth();
   const { addNotification } = useNotifications();
 

--- a/src/Web/autopilot-monitor-web/app/dashboard/components/SessionTable.tsx
+++ b/src/Web/autopilot-monitor-web/app/dashboard/components/SessionTable.tsx
@@ -2,6 +2,7 @@
 
 import { sessionUrl } from "@/lib/routes";
 import { useRouter } from "next/navigation";
+import type { Route } from "next";
 import { useState, useEffect, useRef, useMemo, useDeferredValue } from "react";
 import { Session } from "../types";
 import { trackEvent } from "@/lib/appInsights";
@@ -103,7 +104,7 @@ interface SessionTableProps {
   /** Builds the row's navigation target. Defaults to `/sessions/{id}`; a cross-tenant viewer overrides it to
    * append `?tenantId=` so a delegated viewer opens the session in the managed tenant's (read-only) context.
    * Receives the whole session because the target tenant is per-row (session.tenantId), not derivable from id. */
-  sessionLinkTarget?: (session: Session) => string;
+  sessionLinkTarget?: (session: Session) => Route;
 }
 
 export function SessionTable({

--- a/src/Web/autopilot-monitor-web/app/dashboard/components/SessionTable.tsx
+++ b/src/Web/autopilot-monitor-web/app/dashboard/components/SessionTable.tsx
@@ -761,7 +761,6 @@ export function SessionTable({
 function SessionCell({
   columnKey,
   session,
-  adminMode,
   globalAdminMode,
   blockedDevicesSet,
   user,

--- a/src/Web/autopilot-monitor-web/app/dashboard/components/WelcomeMessage.tsx
+++ b/src/Web/autopilot-monitor-web/app/dashboard/components/WelcomeMessage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { DOCS_URL } from "@/utils/config";
 
 export function WelcomeMessage() {

--- a/src/Web/autopilot-monitor-web/app/dashboard/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/dashboard/page.tsx
@@ -90,9 +90,8 @@ function HomeContent() {
   const mainClassName = fullWidth
     ? "w-full px-4 sm:px-6 lg:px-8 py-4"
     : "max-w-7xl mx-auto py-4 sm:px-6 lg:px-8";
-  const { user, logout, getAccessToken, isPreviewBlocked, hasGlobalScope } = useAuth();
+  const { user, getAccessToken, isPreviewBlocked, hasGlobalScope } = useAuth();
   const { addNotification } = useNotifications();
-  const [apiStatus, setApiStatus] = useState<"unchecked" | "checking" | "healthy" | "error">("unchecked");
   // `?tenant=<id>` deep-links a cross-tenant view onto one tenant — used by the /fleet card grid to drill
   // a managed tenant into this dashboard. Ignored for non-cross-tenant users (the filter is unused there).
   const initialTenantFilter = searchParams?.get("tenant") ?? "";
@@ -109,7 +108,7 @@ function HomeContent() {
   // Drives the stats refetch — server-side stats follow the submitted scope so
   // typing into the filter input doesn't trigger a backend round-trip per keystroke.
   const [submittedTenantIdFilter, setSubmittedTenantIdFilter] = useState(initialTenantFilter);
-  const { adminMode, setAdminMode, globalAdminMode, setGlobalAdminMode } = useAdminMode();
+  const { adminMode, globalAdminMode, setGlobalAdminMode } = useAdminMode();
 
   const signalR = useSignalR();
   const { tenantId } = useTenant();

--- a/src/Web/autopilot-monitor-web/app/diagnosis/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/diagnosis/page.tsx
@@ -802,12 +802,14 @@ function DiagnosisContent() {
   );
 }
 
-function EvidenceEventLinks({ matchedConditions, sessionId }: { matchedConditions: Record<string, any>; sessionId: string }) {
+function EvidenceEventLinks({ matchedConditions, sessionId }: { matchedConditions: Record<string, unknown>; sessionId: string }) {
   const eventLinks: { signal: string; eventId: string; eventType?: string }[] = [];
   const seenEventIds = new Set<string>();
 
-  for (const [signal, evidence] of Object.entries(matchedConditions)) {
+  for (const [signal, evidenceRaw] of Object.entries(matchedConditions)) {
     if (signal.startsWith("factor_")) continue;
+    // Evidence values are rule-engine JSON; only object-shaped entries carry event links.
+    const evidence = evidenceRaw as { eventId?: string; eventType?: string } | string | null;
     if (evidence && typeof evidence === "object" && evidence.eventId) {
       // Multiple matched conditions can extract different fields from the
       // same event — one chip per distinct event, not per condition.

--- a/src/Web/autopilot-monitor-web/app/fleet-health/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/fleet-health/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef, useMemo } from "react";
 import Link from "next/link";
+import type { Route } from "next";
 import { ProtectedRoute } from "../../components/ProtectedRoute";
 import { useSignalR } from "../../contexts/SignalRContext";
 import { useTenant } from "../../contexts/TenantContext";
@@ -192,7 +193,7 @@ export default function FleetHealthPage() {
   // model. The model key is "{Manufacturer} {Model}", which the dashboard search matches
   // against its combined manufacturer+model text. Carry the selected tenant so a global
   // admin scoped to one tenant lands on that tenant's list rather than their default scope.
-  const dashboardModelHref = (model: string) => {
+  const dashboardModelHref = (model: string): Route => {
     const params = new URLSearchParams({ status: "Failed", search: model });
     if (isGlobalAdmin && selectedTenantId) params.set("tenant", selectedTenantId);
     return `/dashboard?${params.toString()}`;

--- a/src/Web/autopilot-monitor-web/app/gather-rules/components/GatherRuleCard.tsx
+++ b/src/Web/autopilot-monitor-web/app/gather-rules/components/GatherRuleCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { GatherRule, NewRuleForm, CATEGORY_COLORS, COLLECTOR_TYPE_LABELS, EMPTY_FORM, formatTrigger, formatGatherPhase, withDerivedScopeMode } from "../types";
+import { GatherRule, NewRuleForm, CATEGORY_COLORS, COLLECTOR_TYPE_LABELS, formatTrigger, formatGatherPhase, withDerivedScopeMode } from "../types";
 import { GatherRuleFormFields } from "./GatherRuleFormFields";
 import { FormJsonToggle, JsonModeToggleButtons, ReadOnlyJsonView } from "@/components/rules/FormJsonToggle";
 import { validateGatherRuleTarget } from "@/utils/guardValidation";
@@ -455,7 +455,7 @@ export function GatherRuleCard({
                   try {
                     const parsed = JSON.parse(jsonText) as NewRuleForm;
                     onSaveEdit(rule, withDerivedScopeMode({ ...editForm, ...parsed }));
-                  } catch (e) {
+                  } catch {
                     // jsonError is handled by parent
                   }
                 } else {

--- a/src/Web/autopilot-monitor-web/app/gather-rules/components/GatherRuleFormFields.tsx
+++ b/src/Web/autopilot-monitor-web/app/gather-rules/components/GatherRuleFormFields.tsx
@@ -363,7 +363,7 @@ export function GatherRuleFormFields({ form, setForm, showRuleId, unrestrictedMo
             />
             <p className="text-xs text-gray-400 mt-1">
               XPath query to extract values. Examples: <code className="bg-gray-100 px-1 rounded">/root/element</code> (path),{" "}
-              <code className="bg-gray-100 px-1 rounded">//element</code> (anywhere),{" "}
+              <code className="bg-gray-100 px-1 rounded">{"//element"}</code> (anywhere),{" "}
               <code className="bg-gray-100 px-1 rounded">/root/item[@attr=&apos;value&apos;]</code> (filter),{" "}
               <code className="bg-gray-100 px-1 rounded">/root/element/text()</code> (text content).
             </p>

--- a/src/Web/autopilot-monitor-web/app/gather-rules/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/gather-rules/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { ProtectedRoute } from "../../components/ProtectedRoute";
 import { useAuth } from "../../contexts/AuthContext";
 import { api } from "@/lib/api";
@@ -16,14 +14,12 @@ import { FormJsonToggle, JsonModeToggleButtons } from "@/components/rules/FormJs
 import { useAuthenticatedFetch, useNotificationMessages, useGlobalAdminScope } from "@/hooks";
 import { GlobalAdminBanner, globalAdminSubtitle } from "@/components/GlobalAdminBanner";
 import { TenantScopeSelector } from "@/components/TenantScopeSelector";
-import { GatherRule, NewRuleForm, EMPTY_FORM, CATEGORY_COLORS, PHASE_TRIGGERS, buildScopeFields, validateScopeSelection, withDerivedScopeMode } from "./types";
+import { GatherRule, NewRuleForm, EMPTY_FORM, PHASE_TRIGGERS, buildScopeFields, validateScopeSelection, withDerivedScopeMode } from "./types";
 import { GatherRuleFormFields } from "./components/GatherRuleFormFields";
 import { GatherRuleCard } from "./components/GatherRuleCard";
 import { DOCS_URL } from "@/utils/config";
 
 export default function GatherRulesPage() {
-  const router = useRouter();
-
   const { user, getAccessToken } = useAuth();
 
   const { successMessage, error, showSuccess, showError } = useNotificationMessages();

--- a/src/Web/autopilot-monitor-web/app/geographic-performance/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/geographic-performance/page.tsx
@@ -144,7 +144,7 @@ export default function GeographicPerformancePage() {
   // Global admin tenant scope (aggregated-capable): tenant list, selection ("" = all tenants),
   // and scope flags. Default selection is the GA's own tenant.
   const scope = useAggregatedAdminScope();
-  const { isGlobalAdmin, routeGlobal, selectedTenantId, isAggregatedGlobalView, scopeInitialized, scopeKey } = scope;
+  const { routeGlobal, selectedTenantId, isAggregatedGlobalView, scopeInitialized, scopeKey } = scope;
 
   const progress = useFetchProgress("geoPerf.lastFetchMs");
   const { begin: progressBegin, finish: progressFinish } = progress;

--- a/src/Web/autopilot-monitor-web/app/geographic-performance/sessions/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/geographic-performance/sessions/page.tsx
@@ -223,7 +223,6 @@ function LocationSessionsContent() {
           <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
             <button
               onClick={() => {
-                const tr = days === "7" ? "7d" : days === "30" ? "30d" : "90d";
                 router.push(`/geographic-performance`);
               }}
               className="text-sm text-gray-600 hover:text-gray-900 mb-2 flex items-center"

--- a/src/Web/autopilot-monitor-web/app/global-error.tsx
+++ b/src/Web/autopilot-monitor-web/app/global-error.tsx
@@ -9,7 +9,6 @@
  * it replaces the entire root layout when triggered.
  */
 export default function GlobalError({
-  error,
   reset,
 }: {
   error: Error & { digest?: string };

--- a/src/Web/autopilot-monitor-web/app/health-check/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/health-check/page.tsx
@@ -14,7 +14,7 @@ interface HealthCheck {
   description: string;
   status: string;
   message: string;
-  details?: Record<string, any>;
+  details?: Record<string, unknown>;
 }
 
 interface HealthCheckResult {
@@ -427,8 +427,8 @@ export default function HealthCheckPage() {
                 updates in place without blocking any of the cards above. */}
             {(() => {
               const display = mcpLoading
-                ? { name: 'MCP Server', description: 'AI query interface availability', status: 'checking', message: 'Probing MCP server — waking it from idle if needed…', details: undefined as Record<string, any> | undefined }
-                : (mcpCheck ?? { name: 'MCP Server', description: 'AI query interface availability', status: 'unknown', message: 'Not checked yet', details: undefined as Record<string, any> | undefined });
+                ? { name: 'MCP Server', description: 'AI query interface availability', status: 'checking', message: 'Probing MCP server — waking it from idle if needed…', details: undefined as Record<string, unknown> | undefined }
+                : (mcpCheck ?? { name: 'MCP Server', description: 'AI query interface availability', status: 'unknown', message: 'Not checked yet', details: undefined as Record<string, unknown> | undefined });
               const colors = getStatusColor(display.status);
               return (
                 <div className={`bg-white dark:bg-gray-800 rounded-lg shadow border-l-4 ${colors.accent}`}>

--- a/src/Web/autopilot-monitor-web/app/ime-log-patterns/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/ime-log-patterns/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
 import { ProtectedRoute } from "../../components/ProtectedRoute";
 import { useTenant } from "../../contexts/TenantContext";
 import { useAuth } from "../../contexts/AuthContext";
@@ -18,8 +17,6 @@ import ImePatternCard from "./components/ImePatternCard";
 import { trackEvent } from "@/lib/appInsights";
 
 export default function ImeLogPatternsPage() {
-  const router = useRouter();
-
   const { tenantId } = useTenant();
   const { user } = useAuth();
   const isGlobalAdmin = user?.isGlobalAdmin ?? false;

--- a/src/Web/autopilot-monitor-web/app/progress/hooks/useProgressDerivedData.ts
+++ b/src/Web/autopilot-monitor-web/app/progress/hooks/useProgressDerivedData.ts
@@ -3,6 +3,30 @@
 import { useEffect, useMemo, useState } from "react";
 import { EnrollmentEvent, Session } from "@/types";
 
+// Minimal structural view of the event payloads this hook reads — only fields used in a
+// typed position are declared (the agent serializes them as strings); everything else
+// stays `unknown` via the index signature.
+interface ProgressEventData {
+  [key: string]: unknown;
+  totalApps?: string;
+  total_apps?: string;
+  installed?: string;
+  failed?: string;
+  installing?: string;
+  downloading?: string;
+  blocking_apps_total?: string;
+  blockingAppsTotal?: string;
+  blocking_apps_completed?: string;
+  blockingAppsCompleted?: string;
+  app_name?: string;
+  appName?: string;
+  file_name?: string;
+  fileName?: string;
+  appId?: string;
+  app_id?: string;
+  status?: string;
+}
+
 export interface AppSummary {
   total: number;
   installed: number;
@@ -54,7 +78,7 @@ export function useProgressDerivedData(
     const summaryEvents = events.filter((e) => e.eventType === "app_tracking_summary");
     if (summaryEvents.length > 0) {
       const latest = summaryEvents[summaryEvents.length - 1];
-      const d = latest.data;
+      const d = latest.data as ProgressEventData | undefined;
       if (d) {
         const total = parseInt(d.totalApps ?? d.total_apps ?? "0", 10);
         if (total > 0) {
@@ -73,7 +97,7 @@ export function useProgressDerivedData(
     const espEvents = events.filter((e) => e.eventType === "esp_ui_state");
     if (espEvents.length > 0) {
       const latest = espEvents[espEvents.length - 1];
-      const d = latest.data;
+      const d = latest.data as ProgressEventData | undefined;
       if (d) {
         const total = parseInt(d.blocking_apps_total ?? d.blockingAppsTotal ?? "0", 10);
         const installed = parseInt(d.blocking_apps_completed ?? d.blockingAppsCompleted ?? "0", 10);
@@ -95,7 +119,7 @@ export function useProgressDerivedData(
       { bytesDownloaded: number; bytesTotal: number; downloadRateBps: number; isComplete: boolean }
     >();
     for (const evt of downloadEvents) {
-      const d = evt.data;
+      const d = evt.data as ProgressEventData | undefined;
       if (!d) continue;
       const appName = d.app_name ?? d.appName ?? d.file_name ?? d.fileName ?? null;
       if (!appName) continue;
@@ -119,7 +143,7 @@ export function useProgressDerivedData(
     const completedCount = Array.from(appLatest.values()).filter((v) => v.isComplete).length;
 
     for (let i = downloadEvents.length - 1; i >= 0; i--) {
-      const d = downloadEvents[i].data;
+      const d = downloadEvents[i].data as ProgressEventData | undefined;
       if (!d) continue;
       const appName = d.app_name ?? d.appName ?? d.file_name ?? d.fileName ?? null;
       if (!appName) continue;
@@ -157,7 +181,7 @@ export function useProgressDerivedData(
 
     const appState = new Map<string, { state: string; startedAt?: string }>();
     for (const evt of sorted) {
-      const d = evt.data;
+      const d = evt.data as ProgressEventData | undefined;
       if (!d) continue;
       const appName = d.appName ?? d.app_name ?? d.appId ?? d.app_id ?? null;
       if (!appName) continue;

--- a/src/Web/autopilot-monitor-web/app/sessions/components/AnalysisResultsSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/components/AnalysisResultsSection.tsx
@@ -304,12 +304,14 @@ function scrollToEvent(eventId: string) {
   }
 }
 
-function EvidenceEventLinks({ matchedConditions }: { matchedConditions: Record<string, any> }) {
+function EvidenceEventLinks({ matchedConditions }: { matchedConditions: Record<string, unknown> }) {
   const eventLinks: { signal: string; eventId: string; eventType?: string }[] = [];
   const seenEventIds = new Set<string>();
 
-  for (const [signal, evidence] of Object.entries(matchedConditions)) {
+  for (const [signal, evidenceRaw] of Object.entries(matchedConditions)) {
     if (signal.startsWith("factor_")) continue;
+    // Evidence values are rule-engine JSON; only object-shaped entries carry event links.
+    const evidence = evidenceRaw as { eventId?: string; eventType?: string } | string | null;
     if (evidence && typeof evidence === "object" && evidence.eventId) {
       // Multiple matched conditions can extract different fields from the
       // same event — one chip per distinct event, not per condition.

--- a/src/Web/autopilot-monitor-web/app/sessions/components/DeviceDetailsCard.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/components/DeviceDetailsCard.tsx
@@ -5,16 +5,35 @@ import { EnrollmentEvent, Session } from "@/types";
 import OobeConfigModal from "./OobeConfigModal";
 import { compareVersions, stripGitHashSuffix } from "@/utils/bootstrapVersion";
 
+// Minimal structural shapes for the event payloads this card reads. Values arrive as
+// deserialized JSON; only the fields the JSX uses in a typed position (string props,
+// arithmetic, Date construction) are declared — everything else stays `unknown`.
+interface AgentStartedData { [key: string]: unknown; agentVersion?: string }
+interface BootTimeData { [key: string]: unknown; bootTimeUtc?: string; bootTime?: string; uptimeMinutes?: number }
+interface OsInfoData { [key: string]: unknown; osVersion?: string; displayVersion?: string; currentBuild?: string; buildRevision?: string; edition?: string; compositionEdition?: string; buildBranch?: string }
+interface NetworkAdaptersData { [key: string]: unknown; adapters?: unknown[] }
+interface DnsConfigData { [key: string]: unknown; dnsEntries?: unknown[] }
+interface NetworkInterfaceInfoData { [key: string]: unknown; status?: string; connectionType?: string; adapterDescription?: string; linkSpeedMbps?: number; gateways?: string }
+interface WifiSignalInfoData { [key: string]: unknown; wifiSsid?: string; wifiSignalPercent?: number; wifiRadioType?: string; wifiChannel?: number }
+interface ProxyConfigData { [key: string]: unknown; proxyType?: string; type?: string; proxyServer?: string; autoConfigUrl?: string; winHttpProxy?: string }
+interface AutopilotProfileData { [key: string]: unknown; PolicyDownloadDate?: string; AutopilotCreationDate?: string; autopilotModeLabel?: string; domainJoinMethodLabel?: string }
+interface ImeVersionData { [key: string]: unknown; version?: string; agentVersion?: string }
+interface RealmJoinInfoData { [key: string]: unknown; productVersion?: string; releaseChannel?: string }
+interface TpmStatusData { [key: string]: unknown; specVersion?: string }
+interface BitLockerStatusData { [key: string]: unknown; volumes?: unknown[] }
+interface DeviceLocationData { [key: string]: unknown; country?: string; Country?: string; timezone?: string; Timezone?: string }
+interface HwSpecData { [key: string]: unknown; cpuName?: string; cpuCores?: string; cpuLogicalProcessors?: string; cpuMaxClockSpeedGHz?: string; cpuArchitecture?: string; ramTotalGB?: string; biosVersion?: string; biosReleaseDate?: string; smbiosVersion?: string; disks?: unknown[]; gpus?: unknown[] }
+
 export default function DeviceDetailsCard({ events, latestAgentVersion, session }: { events: EnrollmentEvent[]; latestAgentVersion?: string | null; session?: Session | null }) {
   const [expanded, setExpanded] = useState(false);
   const [showIpv6, setShowIpv6] = useState<Record<number, boolean>>({});
   const [showOobeModal, setShowOobeModal] = useState(false);
 
-  const getEventData = (eventType: string): Record<string, any> | null => {
+  const getEventData = <T extends Record<string, unknown> = Record<string, unknown>>(eventType: string): T | null => {
     const matchingEvents = events.filter(e => e.eventType === eventType);
     if (matchingEvents.length === 0) return null;
     const latestEvent = matchingEvents[matchingEvents.length - 1];
-    return latestEvent?.data ?? null;
+    return (latestEvent?.data as T | undefined) ?? null;
   };
 
   const isIpv6 = (ip: string): boolean => {
@@ -68,7 +87,7 @@ export default function DeviceDetailsCard({ events, latestAgentVersion, session 
     return names[method] ?? `Unknown (${method})`;
   };
 
-  const normalizeAutopilotProfile = (profile: Record<string, any> | null): Record<string, any> | null => {
+  const normalizeAutopilotProfile = (profile: AutopilotProfileData | null): AutopilotProfileData | null => {
     if (!profile) return null;
 
     const normalized = { ...profile };
@@ -104,13 +123,15 @@ export default function DeviceDetailsCard({ events, latestAgentVersion, session 
     return normalized;
   };
 
-  const hasValue = (value: unknown): boolean => value !== undefined && value !== null && `${value}` !== "";
+  // Type predicate so guarded fields (e.g. PolicyDownloadDate) narrow away undefined.
+  const hasValue = (value: unknown): value is NonNullable<unknown> => value !== undefined && value !== null && `${value}` !== "";
 
-  const agentStarted = getEventData("agent_started");
-  const bootTime = getEventData("boot_time");
+  const agentStarted = getEventData<AgentStartedData>("agent_started");
+  const bootTime = getEventData<BootTimeData>("boot_time");
 
   const estimatedBootTime = (bootTime?.bootTimeUtc || bootTime?.bootTime)
-    ? new Date(bootTime?.bootTimeUtc ?? bootTime?.bootTime)
+    // Non-null: the surrounding guard proves one of the two fields is set.
+    ? new Date((bootTime?.bootTimeUtc ?? bootTime?.bootTime)!)
     : null;
 
   const uptimeUntilEnrollment = useMemo(() => {
@@ -140,26 +161,26 @@ export default function DeviceDetailsCard({ events, latestAgentVersion, session 
     return null;
   }, [bootTime, events]);
 
-  const osInfo = getEventData("os_info");
-  const networkAdapters = getEventData("network_adapters");
-  const dnsConfig = getEventData("dns_configuration");
-  const proxyConfig = getEventData("proxy_configuration");
-  const networkInterfaceInfo = getEventData("network_interface_info");
-  const wifiSignalInfo = getEventData("wifi_signal_info");
-  const autopilotProfile = normalizeAutopilotProfile(getEventData("autopilot_profile"));
+  const osInfo = getEventData<OsInfoData>("os_info");
+  const networkAdapters = getEventData<NetworkAdaptersData>("network_adapters");
+  const dnsConfig = getEventData<DnsConfigData>("dns_configuration");
+  const proxyConfig = getEventData<ProxyConfigData>("proxy_configuration");
+  const networkInterfaceInfo = getEventData<NetworkInterfaceInfoData>("network_interface_info");
+  const wifiSignalInfo = getEventData<WifiSignalInfoData>("wifi_signal_info");
+  const autopilotProfile = normalizeAutopilotProfile(getEventData<AutopilotProfileData>("autopilot_profile"));
   // Explicit agent signal (new sessions) OR ProfileAvailable=0 in the cached profile
   // (also covers sessions recorded before autopilot_profile_missing existed).
   const autopilotProfileMissing =
     getEventData("autopilot_profile_missing") !== null ||
     (autopilotProfile !== null && `${autopilotProfile.ProfileAvailable}` === "0");
   const aadJoinStatus = getEventData("aad_join_status");
-  const imeVersion = getEventData("ime_agent_version");
-  const realmJoinInfo = getEventData("realmjoin_detected");
-  const bitLockerStatus = getEventData("bitlocker_status");
+  const imeVersion = getEventData<ImeVersionData>("ime_agent_version");
+  const realmJoinInfo = getEventData<RealmJoinInfoData>("realmjoin_detected");
+  const bitLockerStatus = getEventData<BitLockerStatusData>("bitlocker_status");
   const secureBootStatus = getEventData("secureboot_status");
-  const tpmStatus = getEventData("tpm_status");
-  const deviceLocation = getEventData("device_location");
-  const hwSpec = getEventData("hardware_spec");
+  const tpmStatus = getEventData<TpmStatusData>("tpm_status");
+  const deviceLocation = getEventData<DeviceLocationData>("device_location");
+  const hwSpec = getEventData<HwSpecData>("hardware_spec");
 
   // Connectivity: agent→backend measurements. Latency comes from the session row (persisted
   // at ingest from the cumulative snapshot counters); bandwidth/volume from their events.
@@ -216,7 +237,7 @@ export default function DeviceDetailsCard({ events, latestAgentVersion, session 
               <DetailSection title="Network">
                 {networkAdapters && networkAdapters.adapters && (
                   (networkAdapters.adapters as unknown[]).map((adapter, i: number) => {
-                    const a = adapter as Record<string, unknown>;
+                    const a = adapter as { [key: string]: unknown; macAddress?: string };
                     const { ipv4, ipv6 } = a.ipAddresses ? splitIpAddresses(a.ipAddresses as string) : { ipv4: [], ipv6: [] };
                     const hasIpv6 = ipv6.length > 0;
                     const isIpv6Shown = showIpv6[i] ?? false;
@@ -424,10 +445,10 @@ export default function DeviceDetailsCard({ events, latestAgentVersion, session 
                   />
                 )}
                 {(deviceLocation?.country || deviceLocation?.Country) && (
-                  <DetailRow label="Country" value={deviceLocation.country ?? deviceLocation.Country} />
+                  <DetailRow label="Country" value={(deviceLocation.country ?? deviceLocation.Country)!} />
                 )}
                 {(deviceLocation?.timezone || deviceLocation?.Timezone) && (
-                  <DetailRow label="Timezone" value={deviceLocation.timezone ?? deviceLocation.Timezone} />
+                  <DetailRow label="Timezone" value={(deviceLocation.timezone ?? deviceLocation.Timezone)!} />
                 )}
               </DetailSection>
             )}
@@ -526,7 +547,7 @@ export default function DeviceDetailsCard({ events, latestAgentVersion, session 
                 {hwSpec.disks && Array.isArray(hwSpec.disks) && (hwSpec.disks as unknown[]).map((disk, i: number) => {
                   const d = disk as Record<string, unknown>;
                   return (
-                  <DetailRow key={`disk-${i}`} label={hwSpec.disks.length > 1 ? `Disk ${i + 1}` : 'Disk'} value={`${d.model || 'Unknown'}${d.sizeGB ? ` (${d.sizeGB} GB)` : ''}${d.mediaType && d.mediaType !== 'Unknown' ? ` — ${d.mediaType}` : ''}`} />
+                  <DetailRow key={`disk-${i}`} label={hwSpec.disks!.length > 1 ? `Disk ${i + 1}` : 'Disk'} value={`${d.model || 'Unknown'}${d.sizeGB ? ` (${d.sizeGB} GB)` : ''}${d.mediaType && d.mediaType !== 'Unknown' ? ` — ${d.mediaType}` : ''}`} />
                   );
                 })}
                 {hwSpec.systemDriveFreeGB !== undefined && hwSpec.systemDriveTotalGB !== undefined && (
@@ -555,7 +576,7 @@ export default function DeviceDetailsCard({ events, latestAgentVersion, session 
                 {hwSpec.gpus && Array.isArray(hwSpec.gpus) && (hwSpec.gpus as unknown[]).map((gpu, i: number) => {
                   const g = gpu as Record<string, unknown>;
                   return (
-                  <DetailRow key={`gpu-${i}`} label={hwSpec.gpus.length > 1 ? `GPU ${i + 1}` : 'GPU'} value={`${g.name || 'Unknown'}${g.adapterRAMGB ? ` (${g.adapterRAMGB} GB)` : ''}`} />
+                  <DetailRow key={`gpu-${i}`} label={hwSpec.gpus!.length > 1 ? `GPU ${i + 1}` : 'GPU'} value={`${g.name || 'Unknown'}${g.adapterRAMGB ? ` (${g.adapterRAMGB} GB)` : ''}`} />
                   );
                 })}
               </DetailSection>

--- a/src/Web/autopilot-monitor-web/app/sessions/components/EventTimeline.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/components/EventTimeline.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { EnrollmentEvent, Session } from "@/types";
 import { normalizeEventDataForDisplay, shortenBuildHashInMessage } from "../utils/eventHelpers";
-import { getErrorCodeEntry, getEnrichedOrLookup, formatErrorCode } from "@/utils/errorCodeMap";
+import { getEnrichedOrLookup, formatErrorCode, type ErrorCodeEntry } from "@/utils/errorCodeMap";
 
 interface EventTimelineProps {
   filteredEvents: EnrollmentEvent[];
@@ -44,7 +44,6 @@ export default function EventTimeline({
   expandAll,
   collapseAll,
   isWhiteGloveSession,
-  whiteGloveSplitSequence,
   orderedPhases,
   eventsByPhase,
   preProvGrouped,
@@ -342,7 +341,7 @@ function PhaseSection({
 
       {isExpanded && (
         <div className="space-y-3">
-          {events.map((event, index) => (
+          {events.map((event) => (
             <EventRow
               key={event.eventId || `${event.sessionId}-${event.sequence}`}
               event={event}
@@ -444,7 +443,6 @@ function EventRow({ event, showScriptOutput }: { event: EnrollmentEvent; showScr
     }
   };
 
-  const hasData = isTruncated || (detailData && Object.keys(detailData).length > 0);
   const hasDetails = true; // Every event has at least the metadata block
 
   const { isBackfilled, recordedAt } = getBackfillInfo(event);
@@ -474,14 +472,14 @@ function EventRow({ event, showScriptOutput }: { event: EnrollmentEvent; showScr
           <p className="mt-1 text-sm text-gray-600" title={event.message || undefined}>{shortenBuildHashInMessage(event.message)}</p>
           {/* Exit code / HRESULT badge for app install events */}
           {(event.eventType === "app_install_failed" || event.eventType === "app_install_completed") && (() => {
-            const ec = event.data?.exitCode ?? event.data?.exit_code;
-            const hr = event.data?.hresultFromWin32 ?? event.data?.hresult_from_win32;
+            const ec = (event.data?.exitCode ?? event.data?.exit_code) as string | number | undefined;
+            const hr = (event.data?.hresultFromWin32 ?? event.data?.hresult_from_win32) as string | number | undefined;
             const hasNonZero = (ec && String(ec) !== "0") || (hr && String(hr) !== "0");
             if (!hasNonZero) return null;
             // Prefer backend-enriched *Info sibling, fall back to local lookup for older
             // responses that pre-date the backend ErrorCodeEnricher.
-            const ecEntry = ec ? getEnrichedOrLookup(event.data?.exitCodeInfo, String(ec)) : null;
-            const hrEntry = hr ? getEnrichedOrLookup(event.data?.hresultFromWin32Info, String(hr)) : null;
+            const ecEntry = ec ? getEnrichedOrLookup(event.data?.exitCodeInfo as ErrorCodeEntry | undefined, String(ec)) : null;
+            const hrEntry = hr ? getEnrichedOrLookup(event.data?.hresultFromWin32Info as ErrorCodeEntry | undefined, String(hr)) : null;
             return (
               <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
                 {ec && String(ec) !== "0" && (
@@ -517,12 +515,13 @@ function EventRow({ event, showScriptOutput }: { event: EnrollmentEvent; showScr
               (e.g. "Apps (0x87d1041c)") and surfaced as top-level event data so the UI can
               render it without parsing nested text. */}
           {(event.eventType === "enrollment_failed" || event.eventType === "esp_provisioning_status" || event.eventType === "esp_failure_advisory" || event.eventType === "esp_appx_failure_analysis") && (() => {
-            const code = event.data?.errorCode ?? event.data?.failedSubcategoryErrorCode ?? event.data?.espErrorCode;
-            const sub = event.data?.failedSubcategory ?? event.data?.failedSubcategories;
+            const code = (event.data?.errorCode ?? event.data?.failedSubcategoryErrorCode ?? event.data?.espErrorCode) as string | number | undefined;
+            const sub = (event.data?.failedSubcategory ?? event.data?.failedSubcategories) as string | undefined;
+            const likelyCulpritApps = event.data?.likelyCulpritApps as string | undefined;
             const isAdvisory = event.eventType === "esp_failure_advisory";
             if (!code && !isAdvisory) return null;
             const codeStr = code ? String(code) : null;
-            const entry = codeStr ? getEnrichedOrLookup(event.data?.errorCodeInfo, codeStr) : null;
+            const entry = codeStr ? getEnrichedOrLookup(event.data?.errorCodeInfo as ErrorCodeEntry | undefined, codeStr) : null;
             // Advisory path uses warning-color palette (amber); the device continued past the
             // failure via ContinueAnyway, so this is not a hard error. PR1 Session 4fa5a2d4.
             const badgeBg = isAdvisory ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800";
@@ -552,12 +551,12 @@ function EventRow({ event, showScriptOutput }: { event: EnrollmentEvent; showScr
                     subcategory: <span className="font-mono">{String(sub)}</span>
                   </span>
                 )}
-                {event.data?.likelyCulpritApps && (
+                {likelyCulpritApps && (
                   <span
                     className="px-1.5 py-0.5 rounded bg-orange-100 text-orange-800 font-medium"
                     title="Tracked app(s) ESP most likely failed on — never-started apps ranked first (snapshot at failure time)."
                   >
-                    Likely app: {String(event.data.likelyCulpritApps)}
+                    Likely app: {String(likelyCulpritApps)}
                   </span>
                 )}
               </div>
@@ -571,7 +570,7 @@ function EventRow({ event, showScriptOutput }: { event: EnrollmentEvent; showScr
             const isRetry = event.eventType === "esp_failure_retry_detected";
             const label = isRetry ? "User retry" : "Recovered";
             const badgeCls = isRetry ? "bg-sky-100 text-sky-800" : "bg-emerald-100 text-emerald-800";
-            const cat = event.data?.category;
+            const cat = event.data?.category as string | undefined;
             const sub = event.data?.subcategory ?? event.data?.failedSubcategory;
             const mins = event.data?.minutesSinceFailure ?? event.data?.minutesSinceAdvisory;
             return (

--- a/src/Web/autopilot-monitor-web/app/sessions/components/MarkFailedModal.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/components/MarkFailedModal.tsx
@@ -29,7 +29,7 @@ export default function MarkFailedModal({ show, session, onConfirm, onCancel }: 
               You are about to manually mark this session as <span className="font-semibold text-red-600">Failed</span>.
             </p>
             <p className="text-sm text-gray-700 mb-2">
-              Session <span className="font-mono text-xs">{session.sessionId}</span> for device <span className="font-semibold">{session.deviceName || session.serialNumber}</span> will be marked as failed with the reason "Manually marked as failed by administrator".
+              Session <span className="font-mono text-xs">{session.sessionId}</span> for device <span className="font-semibold">{session.deviceName || session.serialNumber}</span> will be marked as failed with the reason &quot;Manually marked as failed by administrator&quot;.
             </p>
             <p className="text-sm text-gray-600">
               This action will update the session status and cannot be undone. Do you want to continue?

--- a/src/Web/autopilot-monitor-web/app/sessions/components/OobeConfigModal.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/components/OobeConfigModal.tsx
@@ -40,7 +40,6 @@ export default function OobeConfigModal({ show, value, onClose }: OobeConfigModa
   if (!show) return null;
 
   const hexValue = `0x${value.toString(16).toUpperCase().padStart(4, "0")}`;
-  const binaryValue = value.toString(2).padStart(11, "0");
 
   const isSelfDeploying = (value & 0x0020) !== 0 && (value & 0x0040) !== 0;
   const profileType = isSelfDeploying ? "Self-Deploying" : "User-Driven";

--- a/src/Web/autopilot-monitor-web/app/sessions/components/PhaseTimeline.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/components/PhaseTimeline.tsx
@@ -40,7 +40,8 @@ export default function PhaseTimeline({ currentPhase, completedPhases, events = 
     // Check for app_tracking_summary events (new strategic events)
     const trackingSummary = phaseEvents.find(e => e.eventType === "app_tracking_summary");
     if (trackingSummary?.data) {
-      const d = trackingSummary.data;
+      // Counters are serialized as strings on the wire.
+      const d = trackingSummary.data as Record<string, string | undefined>;
       const completed = parseInt(d.completedApps ?? d.appsCompleted ?? "0", 10);
       const total = parseInt(d.totalApps ?? "0", 10);
       if (total > 0) {
@@ -51,7 +52,7 @@ export default function PhaseTimeline({ currentPhase, completedPhases, events = 
     // Check for esp_ui_state events (legacy) to show app install progress
     const espState = phaseEvents.find(e => e.eventType === "esp_ui_state");
     if (espState?.data) {
-      const d = espState.data;
+      const d = espState.data as Record<string, string | undefined>;
       const completed = parseInt(d.blocking_apps_completed ?? d.blockingAppsCompleted ?? "0", 10);
       const total = parseInt(d.blocking_apps_total ?? d.blockingAppsTotal ?? "0", 10);
       const currentItem = d.current_item ?? d.currentItem ?? d.status_text ?? d.statusText;
@@ -76,7 +77,7 @@ export default function PhaseTimeline({ currentPhase, completedPhases, events = 
     // Check for download_progress to show active download (legacy)
     const downloadEvt = phaseEvents.find(e => e.eventType === "download_progress");
     if (downloadEvt?.data) {
-      const d = downloadEvt.data;
+      const d = downloadEvt.data as Record<string, string | undefined>;
       const appName = d.app_name ?? d.appName ?? "content";
       const pct = d.bytes_total && d.bytes_downloaded
         ? Math.round((parseInt(d.bytes_downloaded) / parseInt(d.bytes_total)) * 100)

--- a/src/Web/autopilot-monitor-web/app/sessions/components/VulnerabilityReportSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/components/VulnerabilityReportSection.tsx
@@ -124,7 +124,7 @@ export default function VulnerabilityReportSection({
   // --- Findings data (wrapped in try/catch to prevent page crash on malformed report data) ---
   const { findings, unmatchedSoftware, mappedNames, unmappedNames, cleanNames, kevTotal, dataFreshness } = useMemo(() => { try {
     const findingsMap = new Map<string, Finding>();
-    let unmatched: string[] = [];
+    const unmatched: string[] = [];
     const mapped = new Set<string>();
     const unmapped = new Set<string>();
     const clean = new Set<string>();
@@ -248,7 +248,8 @@ export default function VulnerabilityReportSection({
     const chunkGroups = new Map<string, { items: InventoryItem[]; chunkCount: number; seenChunks: Set<number> }>();
 
     for (const evt of inventoryEvents) {
-      const d = evt.data || {};
+      // Chunk-envelope fields read in a typed position; the payload itself stays unknown.
+      const d = (evt.data || {}) as { [key: string]: unknown; triggered_at?: string; triggeredAt?: string; chunk_index?: number; chunkIndex?: number; chunk_count?: number; chunkCount?: number };
       const triggeredAt = d.triggered_at || d.triggeredAt || evt.timestamp || "default";
       const chunkIndex = d.chunk_index ?? d.chunkIndex ?? 0;
       const chunkCount = d.chunk_count ?? d.chunkCount ?? 1;

--- a/src/Web/autopilot-monitor-web/app/sessions/hooks/useSessionDerivedData.ts
+++ b/src/Web/autopilot-monitor-web/app/sessions/hooks/useSessionDerivedData.ts
@@ -70,7 +70,8 @@ export function useSessionDerivedData(
     const summaryEvents = events.filter(e => e.eventType === "app_tracking_summary");
     if (summaryEvents.length === 0) return null;
     const latest = summaryEvents[summaryEvents.length - 1];
-    const d = latest.data;
+    // Flat V1 summary schema; counters are serialized as strings on the wire.
+    const d = latest.data as Record<string, string | undefined> | undefined;
     if (!d) return null;
     return {
       totalApps: parseInt(d.totalApps ?? "0", 10),

--- a/src/Web/autopilot-monitor-web/app/sessions/inspector/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/inspector/page.tsx
@@ -184,7 +184,7 @@ function NoV2DataNotice({ sessionId }: { sessionId: string }) {
     <div className="rounded border border-amber-200 bg-amber-50 p-6 text-amber-900">
       <h2 className="font-semibold">No V2 decision data for this session.</h2>
       <p className="mt-2 text-sm">
-        The Inspector relies on the V2-agent's signal log and decision journal.
+        The Inspector relies on the V2-agent&apos;s signal log and decision journal.
         This session likely ran on the legacy (V1) agent, or the V2 telemetry
         never reached the backend. Use the regular{" "}
         <Link

--- a/src/Web/autopilot-monitor-web/app/sessions/utils/eventHelpers.ts
+++ b/src/Web/autopilot-monitor-web/app/sessions/utils/eventHelpers.ts
@@ -219,7 +219,7 @@ export function normalizeJsonLikeValue(value: unknown): any {
   }
 
   if (value && typeof value === "object") {
-    const normalized: Record<string, any> = {};
+    const normalized: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
       normalized[k] = normalizeJsonLikeValue(v);
     }
@@ -229,7 +229,7 @@ export function normalizeJsonLikeValue(value: unknown): any {
   return value;
 }
 
-export function normalizeEventDataForDisplay(data?: Record<string, any>): Record<string, any> | null {
+export function normalizeEventDataForDisplay(data?: Record<string, unknown>): Record<string, unknown> | null {
   if (!data) return null;
   return normalizeJsonLikeValue(data);
 }

--- a/src/Web/autopilot-monitor-web/app/settings/components/DataManagementSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/settings/components/DataManagementSection.tsx
@@ -93,8 +93,8 @@ export default function DataManagementSection({
           <label className="block">
             <span className="text-gray-700 font-medium">Session Timeout (Hours)</span>
             <p className="text-sm text-gray-500 mb-2">
-              Sessions inactive past this timeout are reclassified out of "In Progress": if Device Setup
-              already finished they become "Awaiting User", otherwise they eventually settle as "Incomplete"
+              Sessions inactive past this timeout are reclassified out of &quot;In Progress&quot;: if Device Setup
+              already finished they become &quot;Awaiting User&quot;, otherwise they eventually settle as &quot;Incomplete&quot;
               (a non-completion, not counted as a failure). This keeps stalled sessions from running
               indefinitely and skewing statistics.
               <br />

--- a/src/Web/autopilot-monitor-web/app/settings/components/DiagnosticsSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/settings/components/DiagnosticsSection.tsx
@@ -132,7 +132,7 @@ export default function DiagnosticsSection({
                   </span>
                 </p>
                 <p className="text-xs text-gray-500 mt-0.5">
-                  Uploads go to the Autopilot Monitor backend's Azure Storage. Per-upload, blob-scoped tokens; 15-min TTL.
+                  Uploads go to the Autopilot Monitor backend&apos;s Azure Storage. Per-upload, blob-scoped tokens; 15-min TTL.
                 </p>
               </div>
             </label>
@@ -215,10 +215,10 @@ export default function DiagnosticsSection({
               Hosted storage
             </p>
             <p className="text-sm text-sky-900 mb-2">
-              Diagnostics packages are uploaded to the Autopilot Monitor backend's Azure Storage (operated by the Autopilot Monitor Team). Blobs are isolated per tenant via a <code className="font-mono text-xs bg-sky-100 px-1 rounded">&#123;tenantId&#125;/</code> prefix, and each upload uses a fresh blob-scoped, write-only token (15-min TTL).
+              Diagnostics packages are uploaded to the Autopilot Monitor backend&apos;s Azure Storage (operated by the Autopilot Monitor Team). Blobs are isolated per tenant via a <code className="font-mono text-xs bg-sky-100 px-1 rounded">&#123;tenantId&#125;/</code> prefix, and each upload uses a fresh blob-scoped, write-only token (15-min TTL).
             </p>
             <p className="text-xs text-sky-800">
-              Heads-up: with this option, uploaded contents leave your own Azure tenant boundary. Retention follows your tenant's <strong>Data Retention Days</strong> setting and is enforced by the cascade-delete pipeline — old packages are removed automatically. Review the diagnostics paths section below to see what is collected.
+              Heads-up: with this option, uploaded contents leave your own Azure tenant boundary. Retention follows your tenant&apos;s <strong>Data Retention Days</strong> setting and is enforced by the cascade-delete pipeline — old packages are removed automatically. Review the diagnostics paths section below to see what is collected.
             </p>
           </div>
         )}

--- a/src/Web/autopilot-monitor-web/app/settings/components/McpUsersSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/settings/components/McpUsersSection.tsx
@@ -36,7 +36,7 @@ const POLICY_DESCRIPTIONS: Record<McpPolicy, string> = {
 };
 
 export default function McpUsersSection() {
-  const { getAccessToken, user } = useAuth();
+  const { getAccessToken } = useAuth();
   const { addNotification } = useNotifications();
 
   const [users, setUsers] = useState<McpUser[]>([]);

--- a/src/Web/autopilot-monitor-web/app/settings/tenant/sections/SectionOptionalGraphCapabilities.tsx
+++ b/src/Web/autopilot-monitor-web/app/settings/tenant/sections/SectionOptionalGraphCapabilities.tsx
@@ -121,12 +121,12 @@ export function SectionOptionalGraphCapabilities() {
         <header className="mb-4">
           <h2 className="text-lg font-semibold text-gray-900">Optional Graph capabilities</h2>
           <p className="mt-1 text-sm text-gray-600">
-            Autopilot Monitor's default Microsoft Graph permissions are intentionally minimal. Optional features
+            Autopilot Monitor&apos;s default Microsoft Graph permissions are intentionally minimal. Optional features
             (like resolving Intune Platform Script and Remediation display names in session timelines) require
             additional permissions on the Autopilot Monitor service principal in your tenant. Grant them at any
             time by running the small <span className="font-mono">Grant-AutopilotMonitorAddOn.ps1</span> script
             with a Global Administrator (or Privileged Role Administrator) sign-in — the script does not change
-            the published app manifest, only your tenant's local grant.
+            the published app manifest, only your tenant&apos;s local grant.
           </p>
         </header>
 

--- a/src/Web/autopilot-monitor-web/app/sla/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/sla/page.tsx
@@ -27,7 +27,7 @@ import { trackEvent } from "@/lib/appInsights";
 import { useGlobalAdminScope } from "@/hooks";
 import { GlobalAdminBanner, globalAdminSubtitle } from "@/components/GlobalAdminBanner";
 import { TenantScopeSelector } from "@/components/TenantScopeSelector";
-import { SegmentedControl, TIME_RANGE_OPTIONS } from "@/components/SegmentedControl";
+import { SegmentedControl } from "@/components/SegmentedControl";
 import Link from "next/link";
 import { CardSkeleton } from "@/components/skeletons/PageSkeleton";
 

--- a/src/Web/autopilot-monitor-web/app/usage-metrics/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/usage-metrics/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { useRouter } from 'next/navigation';
 import { useAuth } from '../../contexts/AuthContext';
 import { useNotifications } from '../../contexts/NotificationContext';
 import { ProtectedRoute } from '../../components/ProtectedRoute';
@@ -88,8 +87,6 @@ interface PlatformUsageMetrics {
 }
 
 export default function UsageMetricsPage() {
-  const router = useRouter();
-
   const { getAccessToken } = useAuth();
   const { addNotification } = useNotifications();
   const [metrics, setMetrics] = useState<PlatformUsageMetrics | null>(null);

--- a/src/Web/autopilot-monitor-web/components/ClientRedirect.tsx
+++ b/src/Web/autopilot-monitor-web/components/ClientRedirect.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import type { Route } from "next";
 
 /**
  * Client-side replacement for server `redirect()` index pages — those are not
  * supported under `output: 'export'`. Renders nothing and replaces the history
  * entry on mount (same UX as the role-conditional shell in app/settings/page.tsx).
  */
-export function ClientRedirect({ to }: { to: string }) {
+export function ClientRedirect<T extends string>({ to }: { to: Route<T> }) {
   const router = useRouter();
   useEffect(() => {
     router.replace(to);

--- a/src/Web/autopilot-monitor-web/components/DownloadProgress.tsx
+++ b/src/Web/autopilot-monitor-web/components/DownloadProgress.tsx
@@ -10,7 +10,40 @@ import DoBreakdownBar from "./DoBreakdownBar";
 interface DownloadEvent {
   timestamp: string;
   eventType?: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
+}
+
+// Minimal structural view of the event-data payload: only the fields this panel reads
+// are declared (the agent serializes them as strings); everything else stays `unknown`
+// via the index signature.
+interface DownloadEventData {
+  [key: string]: unknown;
+  app_name?: string;
+  appName?: string;
+  file_name?: string;
+  fileName?: string;
+  app_id?: string;
+  appId?: string;
+  bytes_downloaded?: string;
+  bytesDownloaded?: string;
+  bytes_total?: string;
+  bytesTotal?: string;
+  download_rate_bps?: string;
+  downloadRateBps?: string;
+  status?: string;
+  progress_percent?: string;
+  progressPercent?: string;
+  doFileSize?: string;
+  doBytesFromPeers?: string;
+  doBytesFromHttp?: string;
+  doPercentPeerCaching?: string;
+  doDownloadMode?: string;
+  doDownloadDuration?: string;
+  doBytesFromLanPeers?: string;
+  doBytesFromGroupPeers?: string;
+  doBytesFromInternetPeers?: string;
+  doBytesFromLinkLocalPeers?: string;
+  doBytesFromCacheServer?: string;
 }
 
 interface SummaryStats {
@@ -53,7 +86,7 @@ interface DownloadItem {
   isComplete: boolean;
   isSkipped: boolean;
   firstSeenIndex: number;
-  eventData?: Record<string, any>;
+  eventData?: Record<string, unknown>;
   doStats?: DoStats | null;
 }
 
@@ -105,7 +138,7 @@ export default function DownloadProgress({ events, summaryStats }: DownloadProgr
     let insertionIndex = 0;
 
     for (const evt of sortedEvents) {
-      const d = evt.data;
+      const d = evt.data as DownloadEventData | undefined;
       if (!d) continue;
 
       const appName = d.app_name ?? d.appName ?? d.file_name ?? d.fileName ?? d.app_id ?? d.appId ?? "Unknown App";

--- a/src/Web/autopilot-monitor-web/components/GlobalSidebar.tsx
+++ b/src/Web/autopilot-monitor-web/components/GlobalSidebar.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { useSidebar, PageSectionItem } from "../contexts/SidebarContext";
 import { CollapseState } from "../hooks/useSidebarState";
 import { DefaultSectionIcon, BookOpenIcon, InformationCircleIcon, DocumentTextIcon, ShieldCheckIcon } from "../lib/sidebarIcons";
-import { DASHBOARD_ITEM, NAV_GROUPS, EXPANDABLE_NAV_GROUPS, REGULAR_USER_ITEMS, NavItem, NavGroup, ExpandableNavGroup, ExpandableNavItem } from "../lib/globalNavConfig";
+import { DASHBOARD_ITEM, NAV_GROUPS, EXPANDABLE_NAV_GROUPS, REGULAR_USER_ITEMS, NavItem, NavGroup, ExpandableNavGroup } from "../lib/globalNavConfig";
 import { useAdminMode } from "../hooks/useAdminMode";
 import { DOCS_URL } from "@/utils/config";
 
@@ -17,8 +17,6 @@ export const SIDEBAR_PX: Record<CollapseState, number> = {
   icons: 56,   // w-14
   hidden: 0,
 };
-
-const CHEVRON_W = 16;
 
 const sidebarWidthClass: Record<CollapseState, string> = {
   full: "w-56",

--- a/src/Web/autopilot-monitor-web/components/LegacyPathRedirect.tsx
+++ b/src/Web/autopilot-monitor-web/components/LegacyPathRedirect.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import type { Route } from "next";
 import {
   appDetailUrl,
   backupUrl,
@@ -27,7 +28,7 @@ import {
  * the target shapes.
  */
 
-function legacyTarget(pathname: string, search: URLSearchParams, hash: string): string | null {
+function legacyTarget(pathname: string, search: URLSearchParams, hash: string): Route | null {
   const seg = pathname.replace(/\/+$/, "").split("/").filter(Boolean).map(decodeURIComponent);
 
   // /sessions/{id}/inspector

--- a/src/Web/autopilot-monitor-web/components/Navbar.tsx
+++ b/src/Web/autopilot-monitor-web/components/Navbar.tsx
@@ -7,6 +7,7 @@ import { useTenantNotifications } from '@/contexts/TenantNotificationContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
+import { trustedRoute } from '@/lib/routes';
 import { usePathname, useRouter } from 'next/navigation';
 import { BrandMark } from './BrandMark';
 import { trackEvent } from '@/lib/appInsights';
@@ -138,7 +139,7 @@ export default function Navbar() {
   // so it doesn't linger over the target page.
   const openNotificationHref = (href: string) => {
     setShowNotifications(false);
-    router.push(href);
+    router.push(trustedRoute(href));
   };
 
   const getUserInitials = () => {
@@ -330,7 +331,7 @@ export default function Navbar() {
                                     <p className="text-[10px] text-gray-400">{formatTime(new Date(tn.createdAt))}</p>
                                     {tn.href && (
                                       <Link
-                                        href={tn.href}
+                                        href={trustedRoute(tn.href)}
                                         prefetch={false}
                                         onClick={(e) => { e.stopPropagation(); setShowNotifications(false); }}
                                         className="text-[10px] text-green-700 hover:text-green-800 font-medium underline"
@@ -367,7 +368,7 @@ export default function Navbar() {
                                     <p className="text-[10px] text-gray-400">{formatTime(new Date(gn.createdAt))}</p>
                                     {gn.href && (
                                       <Link
-                                        href={gn.href}
+                                        href={trustedRoute(gn.href)}
                                         prefetch={false}
                                         onClick={(e) => { e.stopPropagation(); setShowNotifications(false); }}
                                         className="text-[10px] text-green-700 hover:text-green-800 font-medium underline"
@@ -401,7 +402,7 @@ export default function Navbar() {
                                     <p className="text-[10px] text-gray-400">{formatTime(notification.timestamp)}</p>
                                     {notification.href && (
                                       <Link
-                                        href={notification.href}
+                                        href={trustedRoute(notification.href)}
                                         prefetch={false}
                                         onClick={(e) => { e.stopPropagation(); markAsRead(notification.id); setShowNotifications(false); }}
                                         className="text-[10px] text-green-700 hover:text-green-800 font-medium underline"

--- a/src/Web/autopilot-monitor-web/components/PerformanceChart.tsx
+++ b/src/Web/autopilot-monitor-web/components/PerformanceChart.tsx
@@ -4,7 +4,30 @@ import { useMemo, useState, useRef, useCallback, useEffect } from "react";
 
 interface PerformanceEvent {
   timestamp: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
+}
+
+// Minimal structural view of the perf-sample payload: only the fields this chart reads
+// are declared (the agent serializes them as strings); everything else stays `unknown`
+// via the index signature.
+interface PerformanceEventData {
+  [key: string]: unknown;
+  cpu_percent?: string;
+  cpuPercent?: string;
+  memory_available_mb?: string;
+  memoryAvailableMb?: string;
+  memory_total_mb?: string;
+  memoryTotalMb?: string;
+  disk_queue_length?: string;
+  diskQueueLength?: string;
+  disk_free_gb?: string;
+  diskFreeGb?: string;
+  disk_total_gb?: string;
+  diskTotalGb?: string;
+  net_receive_rate_kbps?: string;
+  netReceiveRateKbps?: string;
+  net_send_rate_kbps?: string;
+  netSendRateKbps?: string;
 }
 
 interface PerformanceChartProps {
@@ -250,7 +273,7 @@ export default function PerformanceChart({ events, expanded: expandedProp, setEx
     const netTimestamps: string[] = [];
 
     for (const evt of events) {
-      const d = evt.data;
+      const d = evt.data as PerformanceEventData | undefined;
       if (!d) continue;
 
       timestamps.push(new Date(evt.timestamp).toLocaleTimeString());
@@ -282,7 +305,7 @@ export default function PerformanceChart({ events, expanded: expandedProp, setEx
       }
     }
 
-    const last = events[events.length - 1]?.data;
+    const last = events[events.length - 1]?.data as PerformanceEventData | undefined;
     const diskFreeGb = parseFloat(last?.disk_free_gb ?? last?.diskFreeGb ?? "0");
     const diskTotalGb = parseFloat(last?.disk_total_gb ?? last?.diskTotalGb ?? "256");
 

--- a/src/Web/autopilot-monitor-web/components/landing/AuthGate.tsx
+++ b/src/Web/autopilot-monitor-web/components/landing/AuthGate.tsx
@@ -3,6 +3,8 @@
 import { useAuth } from "../../contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import type { Route } from "next";
+import { trustedRoute } from "../../lib/routes";
 import { consumePostLoginReturnUrl } from "../../lib/postLoginReturn";
 import { PORTAL_HOST, shouldCrossOriginToPortal } from "../../lib/hostRouting";
 
@@ -20,12 +22,12 @@ export function AuthGate() {
       // Always consume (read + clear) so a stale deep link can't misroute a later
       // sign-in; only honor it when the user isn't preview-gated.
       const returnUrl = consumePostLoginReturnUrl();
-      let target: string;
+      let target: Route;
       if (isPreviewBlocked) {
         target = "/preview";
       } else if (returnUrl) {
         // Restore the deep link the user originally opened before re-auth.
-        target = returnUrl;
+        target = trustedRoute(returnUrl);
       } else if (user.isDelegated && !user.isTenantAdmin && !user.isGlobalAdmin && !user.isGlobalReader && user.role !== 'Operator') {
         // A delegated ("MSP") admin with no own-tenant/platform role manages a fleet → land on /fleet.
         target = "/fleet";

--- a/src/Web/autopilot-monitor-web/components/rules/FormJsonToggle.tsx
+++ b/src/Web/autopilot-monitor-web/components/rules/FormJsonToggle.tsx
@@ -16,7 +16,6 @@ interface FormJsonToggleProps {
 
 export function FormJsonToggle({
   jsonMode,
-  onToggleMode,
   jsonText,
   onJsonTextChange,
   jsonError,

--- a/src/Web/autopilot-monitor-web/contexts/SidebarContext.tsx
+++ b/src/Web/autopilot-monitor-web/contexts/SidebarContext.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback, ReactNode } from "react";
+import type { Route } from "next";
 import { useSidebarState, CollapseState } from "../hooks/useSidebarState";
 
 export interface PageSectionItem {
   id: string;
   label: string;
   icon?: ReactNode;
-  href?: string;
+  href?: Route;
   /** Optional group name — items sharing the same group are rendered under a collapsible header */
   group?: string;
   /** Icon for the group header (only needs to be set on the first item of a group) */

--- a/src/Web/autopilot-monitor-web/contexts/SignalRContext.tsx
+++ b/src/Web/autopilot-monitor-web/contexts/SignalRContext.tsx
@@ -7,13 +7,17 @@ import { authenticatedFetch } from '@/lib/authenticatedFetch';
 import { trackEvent } from '@/lib/appInsights';
 import { useAuth } from './AuthContext';
 
+// Hub payloads are untyped JSON; mirror @microsoft/signalr's own callback signature so
+// consumer handlers keep their narrower parameter types without laundering here.
+type SignalRHandler = Parameters<signalR.HubConnection["on"]>[1];
+
 interface SignalRContextType {
   connection: signalR.HubConnection | null;
   connectionState: signalR.HubConnectionState;
   connectionId: string | null;
-  on: (eventName: string, callback: (...args: any[]) => void) => void;
-  off: (eventName: string, callback: (...args: any[]) => void) => void;
-  invoke: (methodName: string, ...args: any[]) => Promise<any>;
+  on: (eventName: string, callback: SignalRHandler) => void;
+  off: (eventName: string, callback: SignalRHandler) => void;
+  invoke: (methodName: string, ...args: unknown[]) => Promise<unknown>;
   joinGroup: (groupName: string) => Promise<void>;
   leaveGroup: (groupName: string) => Promise<void>;
   isConnected: boolean;
@@ -99,7 +103,7 @@ export function SignalRProvider({ children }: { children: React.ReactNode }) {
       disconnectStartedAtRef.current = null;
     });
 
-    newConnection.onreconnecting((error) => {
+    newConnection.onreconnecting(() => {
       setConnectionState(signalR.HubConnectionState.Reconnecting);
       disconnectStartedAtRef.current = performance.now();
     });
@@ -220,19 +224,19 @@ export function SignalRProvider({ children }: { children: React.ReactNode }) {
     };
   }, [isAuthenticated, getAccessToken]);
 
-  const on = (eventName: string, callback: (...args: any[]) => void) => {
+  const on = (eventName: string, callback: SignalRHandler) => {
     if (connectionRef.current) {
       connectionRef.current.on(eventName, callback);
     }
   };
 
-  const off = (eventName: string, callback: (...args: any[]) => void) => {
+  const off = (eventName: string, callback: SignalRHandler) => {
     if (connectionRef.current) {
       connectionRef.current.off(eventName, callback);
     }
   };
 
-  const invoke = async (methodName: string, ...args: any[]) => {
+  const invoke = async (methodName: string, ...args: unknown[]): Promise<unknown> => {
     if (connection && connectionState === signalR.HubConnectionState.Connected) {
       return await connection.invoke(methodName, ...args);
     }

--- a/src/Web/autopilot-monitor-web/eslint.config.mjs
+++ b/src/Web/autopilot-monitor-web/eslint.config.mjs
@@ -1,5 +1,7 @@
 // Flat ESLint config (Next 16 removed `next lint`; run via `npm run lint`).
-// Not wired into CI — kept runnable for local/spot use only.
+// CI gates on this: errors fail the web job, warnings are ratcheted via
+// --max-warnings (see .github/workflows/ci.yml) — lower the cap when you fix
+// warnings, never raise it.
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 
@@ -16,6 +18,30 @@ const config = [
   },
   ...nextVitals,
   ...nextTs,
+  {
+    // The React-Compiler-powered hooks rules (new in eslint-plugin-react-hooks
+    // v6 via eslint-config-next 16) flag long-standing patterns whose cleanup
+    // is a behavioral refactor per site (auth/SignalR/MSAL-adjacent code), not
+    // a mechanical fix. Kept visible as warnings and burned down incrementally
+    // under the CI warning ratchet; do NOT silence individual sites with
+    // eslint-disable instead of fixing them.
+    rules: {
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/refs": "warn",
+      "react-hooks/static-components": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/immutability": "warn",
+      "react-hooks/preserve-manual-memoization": "warn",
+    },
+  },
+  {
+    // Build/maintenance scripts are Node CommonJS on purpose (the package is
+    // not type:module) — require() is the correct import form there.
+    files: ["scripts/**/*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
 ];
 
 export default config;

--- a/src/Web/autopilot-monitor-web/lib/__tests__/installProgress.test.ts
+++ b/src/Web/autopilot-monitor-web/lib/__tests__/installProgress.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildInstallItems, type InstallEvent } from "@/lib/installProgress";
 
-function evt(eventType: string, timestamp: string, data: Record<string, any>): InstallEvent {
+function evt(eventType: string, timestamp: string, data: Record<string, unknown>): InstallEvent {
   return { eventType, timestamp, data };
 }
 

--- a/src/Web/autopilot-monitor-web/lib/__tests__/scriptExecutions.test.ts
+++ b/src/Web/autopilot-monitor-web/lib/__tests__/scriptExecutions.test.ts
@@ -17,7 +17,7 @@ import {
 
 const ts = (offsetSeconds: number) => new Date(1700000000000 + offsetSeconds * 1000).toISOString();
 
-const finalEvent = (overrides: Partial<{ eventType: string; ts: number; data: Record<string, any> }> = {}): ScriptInputEvent => ({
+const finalEvent = (overrides: Partial<{ eventType: string; ts: number; data: Record<string, unknown> }> = {}): ScriptInputEvent => ({
   timestamp: ts(overrides.ts ?? 0),
   eventType: overrides.eventType ?? "script_completed",
   data: overrides.data ?? {},

--- a/src/Web/autopilot-monitor-web/lib/globalNavConfig.tsx
+++ b/src/Web/autopilot-monitor-web/lib/globalNavConfig.tsx
@@ -4,11 +4,7 @@ import {
   DocumentTextIcon,
   ShieldCheckIcon,
   BuildingOfficeIcon,
-  NoSymbolIcon,
-  KeyIcon,
   SparklesIcon,
-  ArrowDownTrayIcon,
-  ArrowPathIcon,
   FolderIcon,
   WrenchScrewdriverIcon,
 } from "./sidebarIcons";

--- a/src/Web/autopilot-monitor-web/lib/globalNavConfig.tsx
+++ b/src/Web/autopilot-monitor-web/lib/globalNavConfig.tsx
@@ -12,6 +12,8 @@ import {
   FolderIcon,
   WrenchScrewdriverIcon,
 } from "./sidebarIcons";
+import type { Route } from "next";
+import { route } from "./routes";
 
 // --- Icons defined inline (not in sidebarIcons) ---
 
@@ -84,7 +86,7 @@ function WrenchIcon({ className = "w-5 h-5" }: { className?: string }) {
 export interface NavItem {
   id: string;
   label: string;
-  href: string;
+  href: Route;
   icon: React.ReactNode;
 }
 
@@ -92,7 +94,7 @@ export interface NavItem {
 export interface ExpandableSubItem {
   id: string;
   label: string;
-  href: string;
+  href: Route;
 }
 
 /** An expandable group with icon + chevron, containing sub-items */
@@ -201,38 +203,38 @@ export const EXPANDABLE_NAV_GROUPS: ExpandableNavGroup[] = [
       {
         id: "cfg-tenant", label: "Tenant", icon: <BuildingOfficeIcon />,
         items: [
-          { id: "cfg-access-mgmt", label: "Access Management", href: "/settings/tenant/access-management" },
-          { id: "cfg-autopilot", label: "Autopilot Validation", href: "/settings/tenant/autopilot" },
-          { id: "cfg-hardware", label: "Hardware Whitelist", href: "/settings/tenant/hardware-whitelist" },
-          { id: "cfg-notifications", label: "Notifications", href: "/settings/tenant/notifications" },
-          { id: "cfg-sla-targets", label: "SLA Targets", href: "/settings/tenant/sla-targets" },
-          { id: "cfg-bootstrap-sessions", label: "Bootstrap Sessions", href: "/settings/tenant/bootstrap-sessions" },
-          { id: "cfg-graph-permissions", label: "Optional Graph capabilities", href: "/settings/tenant/graph-permissions" },
-          { id: "cfg-support", label: "Submit Logs", href: "/settings/tenant/support" },
-          { id: "cfg-plan", label: "Plan", href: "/settings/tenant/plan" },
-          { id: "cfg-contact", label: "Contact", href: "/settings/tenant/contact" },
+          { id: "cfg-access-mgmt", label: "Access Management", href: route("/settings/tenant/access-management") },
+          { id: "cfg-autopilot", label: "Autopilot Validation", href: route("/settings/tenant/autopilot") },
+          { id: "cfg-hardware", label: "Hardware Whitelist", href: route("/settings/tenant/hardware-whitelist") },
+          { id: "cfg-notifications", label: "Notifications", href: route("/settings/tenant/notifications") },
+          { id: "cfg-sla-targets", label: "SLA Targets", href: route("/settings/tenant/sla-targets") },
+          { id: "cfg-bootstrap-sessions", label: "Bootstrap Sessions", href: route("/settings/tenant/bootstrap-sessions") },
+          { id: "cfg-graph-permissions", label: "Optional Graph capabilities", href: route("/settings/tenant/graph-permissions") },
+          { id: "cfg-support", label: "Submit Logs", href: route("/settings/tenant/support") },
+          { id: "cfg-plan", label: "Plan", href: route("/settings/tenant/plan") },
+          { id: "cfg-contact", label: "Contact", href: route("/settings/tenant/contact") },
         ],
       },
       {
         id: "cfg-agent", label: "Agent", icon: <GearIcon />,
         items: [
-          { id: "cfg-agent-settings", label: "Agent Settings", href: "/settings/agent/settings" },
-          { id: "cfg-agent-analyzers", label: "Agent Analyzers", href: "/settings/agent/analyzers" },
-          { id: "cfg-diagnostics", label: "Diagnostics Package", href: "/settings/agent/diagnostics" },
-          { id: "cfg-agent-unrestricted", label: "Unrestricted Mode", href: "/settings/agent/unrestricted-mode" },
+          { id: "cfg-agent-settings", label: "Agent Settings", href: route("/settings/agent/settings") },
+          { id: "cfg-agent-analyzers", label: "Agent Analyzers", href: route("/settings/agent/analyzers") },
+          { id: "cfg-diagnostics", label: "Diagnostics Package", href: route("/settings/agent/diagnostics") },
+          { id: "cfg-agent-unrestricted", label: "Unrestricted Mode", href: route("/settings/agent/unrestricted-mode") },
         ],
       },
       {
         id: "cfg-maintenance", label: "Maintenance", icon: <WrenchScrewdriverIcon />,
         items: [
-          { id: "cfg-data", label: "Data Management", href: "/settings/management/data" },
-          { id: "cfg-offboarding", label: "Offboarding", href: "/settings/management/offboarding" },
+          { id: "cfg-data", label: "Data Management", href: route("/settings/management/data") },
+          { id: "cfg-offboarding", label: "Offboarding", href: route("/settings/management/offboarding") },
         ],
       },
       {
         id: "cfg-reporting", label: "Reporting", icon: <ChartBarIcon />,
         items: [
-          { id: "cfg-mcp-usage", label: "MCP Usage", href: "/settings/reporting/mcp-usage" },
+          { id: "cfg-mcp-usage", label: "MCP Usage", href: route("/settings/reporting/mcp-usage") },
         ],
       },
     ],
@@ -246,34 +248,34 @@ export const EXPANDABLE_NAV_GROUPS: ExpandableNavGroup[] = [
       {
         id: "ga-tenants", label: "Tenants", icon: <BuildingOfficeIcon />,
         items: [
-          { id: "ga-tenant-mgmt", label: "Tenant Management", href: "/admin/tenants/management" },
-          { id: "ga-config-report", label: "Config Report", href: "/admin/tenants/config-report" },
+          { id: "ga-tenant-mgmt", label: "Tenant Management", href: route("/admin/tenants/management") },
+          { id: "ga-config-report", label: "Config Report", href: route("/admin/tenants/config-report") },
         ],
       },
       {
         id: "ga-metrics", label: "Metrics", icon: <ChartBarIcon />,
         items: [
-          { id: "ga-platform-metrics", label: "Platform Metrics", href: "/admin/metrics/platform-metrics" },
-          { id: "ga-usage", label: "Platform Usage", href: "/admin/metrics/usage" },
+          { id: "ga-platform-metrics", label: "Platform Metrics", href: route("/admin/metrics/platform-metrics") },
+          { id: "ga-usage", label: "Platform Usage", href: route("/admin/metrics/usage") },
           { id: "ga-active-users", label: "Active Users", href: "/admin/presence" },
-          { id: "ga-mcp-usage", label: "MCP Usage", href: "/admin/metrics/mcp-usage" },
+          { id: "ga-mcp-usage", label: "MCP Usage", href: route("/admin/metrics/mcp-usage") },
         ],
       },
       {
         id: "ga-reports", label: "Reports", icon: <DocumentTextIcon />,
         items: [
-          { id: "ga-session-reports", label: "Session Reports", href: "/admin/reports/session-reports" },
-          { id: "ga-distress-reports", label: "Distress Reports", href: "/admin/reports/distress-reports" },
-          { id: "ga-user-feedback", label: "User Feedback", href: "/admin/reports/user-feedback" },
-          { id: "ga-session-export", label: "Session Export", href: "/admin/reports/session-export" },
+          { id: "ga-session-reports", label: "Session Reports", href: route("/admin/reports/session-reports") },
+          { id: "ga-distress-reports", label: "Distress Reports", href: route("/admin/reports/distress-reports") },
+          { id: "ga-user-feedback", label: "User Feedback", href: route("/admin/reports/user-feedback") },
+          { id: "ga-session-export", label: "Session Export", href: route("/admin/reports/session-export") },
         ],
       },
       {
         id: "ga-security", label: "Security", icon: <ShieldCheckIcon />,
         items: [
-          { id: "ga-device-block", label: "Device Block", href: "/admin/security/device-block" },
-          { id: "ga-version-block", label: "Version Block", href: "/admin/security/version-block" },
-          { id: "ga-vulnerability", label: "Vulnerability Data", href: "/admin/security/vulnerability-data" },
+          { id: "ga-device-block", label: "Device Block", href: route("/admin/security/device-block") },
+          { id: "ga-version-block", label: "Version Block", href: route("/admin/security/version-block") },
+          { id: "ga-vulnerability", label: "Vulnerability Data", href: route("/admin/security/vulnerability-data") },
         ],
       },
       {
@@ -281,13 +283,13 @@ export const EXPANDABLE_NAV_GROUPS: ExpandableNavGroup[] = [
         // are mutation surfaces; the reader gets redacted/read-only tenant config elsewhere).
         id: "ga-settings", label: "Settings", icon: <GearIcon />, visibility: "globalAdminOnly",
         items: [
-          { id: "ga-global", label: "Global Settings", href: "/admin/settings/global" },
-          { id: "ga-diag-paths", label: "Diagnostics Log Paths", href: "/admin/settings/diagnostics-log-paths" },
-          { id: "ga-mcp-users", label: "MCP Users", href: "/admin/settings/mcp-users" },
-          { id: "ga-delegated-admins", label: "Delegated Admins", href: "/admin/settings/delegated-admins" },
-          { id: "ga-tenant-groups", label: "Tenant Groups", href: "/admin/settings/tenant-groups" },
-          { id: "ga-config-reseed", label: "Config Reseed", href: "/admin/settings/config-reseed" },
-          { id: "ga-usage-plans", label: "Usage Plans", href: "/admin/settings/usage-plans" },
+          { id: "ga-global", label: "Global Settings", href: route("/admin/settings/global") },
+          { id: "ga-diag-paths", label: "Diagnostics Log Paths", href: route("/admin/settings/diagnostics-log-paths") },
+          { id: "ga-mcp-users", label: "MCP Users", href: route("/admin/settings/mcp-users") },
+          { id: "ga-delegated-admins", label: "Delegated Admins", href: route("/admin/settings/delegated-admins") },
+          { id: "ga-tenant-groups", label: "Tenant Groups", href: route("/admin/settings/tenant-groups") },
+          { id: "ga-config-reseed", label: "Config Reseed", href: route("/admin/settings/config-reseed") },
+          { id: "ga-usage-plans", label: "Usage Plans", href: route("/admin/settings/usage-plans") },
         ],
       },
       {

--- a/src/Web/autopilot-monitor-web/lib/historicReplay.ts
+++ b/src/Web/autopilot-monitor-web/lib/historicReplay.ts
@@ -14,7 +14,7 @@ export const HISTORIC_REPLAY_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 export interface ReplayInputEvent {
   timestamp: string;
   eventType?: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
 }
 
 export interface HistoricPartition<T extends ReplayInputEvent> {

--- a/src/Web/autopilot-monitor-web/lib/installProgress.ts
+++ b/src/Web/autopilot-monitor-web/lib/installProgress.ts
@@ -5,7 +5,37 @@
 export interface InstallEvent {
   timestamp: string;
   eventType?: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
+}
+
+// Minimal structural view of the event-data payload: only the fields this aggregation
+// reads are declared (the agent serializes them as strings); everything else stays
+// `unknown` via the index signature.
+interface InstallEventData {
+  [key: string]: unknown;
+  appName?: string;
+  app_name?: string;
+  appId?: string;
+  app_id?: string;
+  displayName?: string;
+  display_name?: string;
+  packageId?: string;
+  package_id?: string;
+  exitCode?: string;
+  exit_code?: string;
+  lastExitCode?: string;
+  last_exit_code?: string;
+  hresultFromWin32?: string;
+  hresult_from_win32?: string;
+  failureType?: string;
+  failure_type?: string;
+  confidence?: string;
+  errorDetail?: string;
+  error_detail?: string;
+  errorPatternId?: string;
+  error_pattern_id?: string;
+  errorCode?: string;
+  error_code?: string;
 }
 
 // Where an install row was observed. `ime` is the default and stays unlabelled in the UI —
@@ -54,7 +84,7 @@ export interface InstallItem {
   isDetectionFailure: boolean;
   isInstallFailure: boolean;
   firstSeenIndex: number;
-  eventData?: Record<string, any>;
+  eventData?: Record<string, unknown>;
 }
 
 // Canonical V2 agent `failureType` identifiers — mirrors
@@ -98,7 +128,7 @@ export function buildInstallItems(events: InstallEvent[]): InstallItem[] {
   let insertionIndex = 0;
 
   for (const evt of sortedEvents) {
-    const d = evt.data;
+    const d = evt.data as InstallEventData | undefined;
     if (!d) continue;
 
     const type = evt.eventType;

--- a/src/Web/autopilot-monitor-web/lib/routes.ts
+++ b/src/Web/autopilot-monitor-web/lib/routes.ts
@@ -12,38 +12,41 @@
  * Rule: the fragment (#...) always comes AFTER the query string.
  */
 
-function withQuery(
-  path: string,
+import type { Route } from "next";
+
+function withQuery<T extends string>(
+  path: Route<T>,
   params: Record<string, string | undefined>,
   hash?: string,
-): string {
+): Route {
   const qs = Object.entries(params)
     .filter(([, v]) => v !== undefined && v !== "")
     .map(([k, v]) => `${k}=${encodeURIComponent(v as string)}`)
     .join("&");
   const fragment = hash ? (hash.startsWith("#") ? hash : `#${hash}`) : "";
-  return `${path}${qs ? `?${qs}` : ""}${fragment}`;
+  // Appending a query/fragment to an already-validated Route keeps it valid.
+  return `${path}${qs ? `?${qs}` : ""}${fragment}` as Route;
 }
 
 export function sessionUrl(
   sessionId: string,
   opts?: { tenantId?: string; hash?: string },
-): string {
+): Route {
   return withQuery("/sessions", { id: sessionId, tenantId: opts?.tenantId }, opts?.hash);
 }
 
-export function inspectorUrl(sessionId: string, opts?: { tab?: string }): string {
+export function inspectorUrl(sessionId: string, opts?: { tab?: string }): Route {
   return withQuery("/sessions/inspector", { id: sessionId, tab: opts?.tab });
 }
 
-export function diagnosisUrl(sessionId: string): string {
+export function diagnosisUrl(sessionId: string): Route {
   return withQuery("/diagnosis", { id: sessionId });
 }
 
 export function appDetailUrl(
   appName: string,
   opts?: { days?: string; tenantId?: string },
-): string {
+): Route {
   return withQuery("/apps/detail", {
     name: appName,
     days: opts?.days,
@@ -51,13 +54,43 @@ export function appDetailUrl(
   });
 }
 
-export function backupUrl(backupId: string): string {
+export function backupUrl(backupId: string): Route {
   return withQuery("/admin/backups/detail", { id: backupId });
 }
 
-export function customsArchiveUrl(tenantId: string, historyRowKey: string): string {
+export function deviceBlockUrl(
+  sessionId: string,
+  reason: string,
+  action?: "Block" | "Kill",
+): Route {
+  return withQuery("/admin/security/device-block", { sessionId, reason, action });
+}
+
+export function customsArchiveUrl(tenantId: string, historyRowKey: string): Route {
   return withQuery("/admin/customs-archive/detail", {
     tenantId,
     rowKey: historyRowKey,
   });
+}
+
+/**
+ * Compile-time validates a route literal that targets a DYNAMIC route (e.g.
+ * `/admin/settings/[section]`): the bare `Route` type only covers static
+ * routes, so dynamic-section literals — nav configs, section index redirects —
+ * go through this identity helper, where inference of `T` runs the literal
+ * against the generated route union. A typo'd prefix is a compile error.
+ */
+export function route<T extends string>(href: Route<T>): Route {
+  return href as Route;
+}
+
+/**
+ * Brands an in-app href that only exists at runtime (backend-emitted
+ * notification deep links, the persisted post-login return URL) for the typed
+ * router APIs. The compiler cannot validate data, only literals — producers of
+ * these hrefs are responsible for emitting canonical shapes (ideally via the
+ * builders above). Keep every such cast behind this single seam.
+ */
+export function trustedRoute(href: string): Route {
+  return href as Route;
 }

--- a/src/Web/autopilot-monitor-web/lib/scriptDisplayNames.ts
+++ b/src/Web/autopilot-monitor-web/lib/scriptDisplayNames.ts
@@ -191,7 +191,6 @@ export function useScriptDisplayNames(
         setByRefKey(refsMap);
       } catch (err) {
         if (err instanceof TokenExpiredError) return; // user signed out / token expired
-        // eslint-disable-next-line no-console
         console.warn("useScriptDisplayNames: lookup failed", err);
       }
     })();

--- a/src/Web/autopilot-monitor-web/lib/scriptExecutions.ts
+++ b/src/Web/autopilot-monitor-web/lib/scriptExecutions.ts
@@ -10,7 +10,27 @@ import { HISTORIC_REPLAY_THRESHOLD_MS, partitionHistoricReplayEvents } from "./h
 export interface ScriptInputEvent {
   timestamp: string;
   eventType?: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
+}
+
+// Minimal structural view of the event-data payload: only the fields the reducer reads
+// in a typed position are declared (the agent serializes them as strings); numeric-ish
+// fields go through `toNumber` and stay `unknown` via the index signature.
+interface ScriptEventData {
+  [key: string]: unknown;
+  policyId?: string;
+  policy_id?: string;
+  scriptType?: string;
+  script_type?: string;
+  scriptPart?: string;
+  script_part?: string;
+  runContext?: string;
+  run_context?: string;
+  result?: string;
+  complianceResult?: string;
+  compliance_result?: string;
+  errorDetails?: string;
+  error_details?: string;
 }
 
 export interface ScriptItem {
@@ -265,7 +285,7 @@ export function reduceScriptEvents(events: ScriptInputEvent[]): ScriptItem[] {
   for (let idx = 0; idx < sorted.length; idx++) {
     const evt = sorted[idx];
     if (evt.eventType !== "script_completed" && evt.eventType !== "script_failed") continue;
-    const d = evt.data;
+    const d = evt.data as ScriptEventData | undefined;
     if (!d) continue;
 
     const policyId = d.policyId ?? d.policy_id ?? "";
@@ -384,7 +404,7 @@ export function reduceScriptEvents(events: ScriptInputEvent[]): ScriptItem[] {
   const runningEmitted = new Set<string>();
   for (const evt of sorted) {
     if (evt.eventType !== "script_started") continue;
-    const d = evt.data;
+    const d = evt.data as ScriptEventData | undefined;
     if (!d) continue;
 
     const policyId = d.policyId ?? d.policy_id ?? "";

--- a/src/Web/autopilot-monitor-web/next.config.ts
+++ b/src/Web/autopilot-monitor-web/next.config.ts
@@ -25,6 +25,10 @@ const nextConfig: NextConfig = {
   // all client state (e.g. the sidebar collapses on each click).
   ...(isDev ? { skipTrailingSlashRedirect: true } : {}),
   reactStrictMode: true,
+  // Statically typed links: `next typegen` derives a Route union from the app
+  // tree, so a broken internal <Link>/router.push target is a compile error —
+  // the failure class behind the recent RSC/routing incidents.
+  typedRoutes: true,
   experimental: {
     // Rewrite these heavy packages to per-module imports so unused exports are
     // tree-shaken out of the route chunks that touch them.

--- a/src/Web/autopilot-monitor-web/types/enrollment.ts
+++ b/src/Web/autopilot-monitor-web/types/enrollment.ts
@@ -10,7 +10,7 @@ export interface EnrollmentEvent {
   message: string;
   sequence: number;
   receivedAt?: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
 }
 
 export interface RuleResult {
@@ -25,6 +25,6 @@ export interface RuleResult {
   explanation: string;
   remediation: { title: string; steps: string[] }[];
   relatedDocs: { title: string; url: string }[];
-  matchedConditions: Record<string, any>;
+  matchedConditions: Record<string, unknown>;
   detectedAt: string;
 }


### PR DESCRIPTION
## Summary

Stacked on #115 — **merge #115 first**, then this one (after #115 lands, the net diff of this PR is the lint changes only).

Package deal: fixes only land together with the CI gate, otherwise they drift right back. The CI web job now runs `npm run lint -- --max-warnings 163`: errors fail outright, the warning cap is a ratchet (lower it when fixing warnings, never raise it).

Fixed to zero (mechanical categories, behavior unchanged):
- `no-unused-vars` (49): dead imports/locals removed; where a prop is part of a live call-site contract, only the destructured binding was dropped
- `no-explicit-any` (29): real structural types for event payloads (`EnrollmentEvent.data` et al → `Record<string, unknown>` + per-event interfaces); SignalR passthroughs typed via the library''s own signatures
- `no-unescaped-entities` (15), `prefer-const`, `jsx-no-comment-textnodes`
- `no-require-imports` (5): `scripts/**/*.js` override — Node CJS scripts, `require()` is correct there
- one stale `eslint-disable` directive removed

**Deliberately NOT fixed inline:** the React-Compiler hooks rules new in eslint-plugin-react-hooks v6 (`set-state-in-effect` 93, `refs` 26, `static-components` 14, `purity` 6, `immutability` 5, `preserve-manual-memoization` 3) are demoted to `warn` in `eslint.config.mjs` — each is a per-site behavioral refactor in auth/SignalR-adjacent code, to be burned down incrementally under the ratchet. No per-site `eslint-disable` allowed or added.

## Verification

- eslint: 0 errors / exactly 163 warnings; the CI gate command exits 0
- `tsc --noEmit` clean, vitest 611/611, static export builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)