### PR TITLE
Transactional tenant-config writes via MCP + ConfigurationBackups safety net

### DIFF
--- a/src/Backend/AutopilotMonitor.Functions.Tests/AdminConfigurationRateLimitSyncTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/AdminConfigurationRateLimitSyncTests.cs
@@ -51,5 +51,7 @@ public class AdminConfigurationRateLimitSyncTests
         // ...but NO tenant configuration is enumerated or mutated (sync removed).
         repo.Verify(r => r.GetAllTenantConfigurationsAsync(), Times.Never);
         repo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        repo.Verify(r => r.SaveTenantConfigurationAsync(
+            It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 }

--- a/src/Backend/AutopilotMonitor.Functions.Tests/AppHomingServiceTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/AppHomingServiceTests.cs
@@ -104,7 +104,7 @@ public class AppHomingServiceTests
         _adminConfigMock.Setup(x => x.IsSelfServiceAppHomingEnabledAsync()).ReturnsAsync(true);
         var config = LegacyHomedConfig();
         _tenantConfigMock.Setup(x => x.GetConfigurationFreshAsync(TenantId)).ReturnsAsync(config);
-        _tenantConfigMock.Setup(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        _tenantConfigMock.Setup(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
         SetupProbe(GraphTokenResult.Success("tok"));
     }
@@ -172,7 +172,7 @@ public class AppHomingServiceTests
         Assert.Equal(AppHomingAutoFlipOutcome.Flipped, outcome);
         _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.Is<TenantConfiguration>(c =>
             string.Equals(c.HomedAppClientId, PrimaryId, StringComparison.OrdinalIgnoreCase)
-            && c.UpdatedBy == Actor)), Times.Once);
+            && c.UpdatedBy == Actor), It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         _detectorMock.Verify(x => x.InvalidateTenant(TenantId), Times.Once);
         _maintenanceMock.Verify(m => m.LogAuditEntryAsync(TenantId, "UPDATE", "TenantConfiguration",
             TenantId, Actor, It.Is<Dictionary<string, string>?>(d =>
@@ -189,7 +189,7 @@ public class AppHomingServiceTests
         var outcome = await _sut.TryAutoFlipToPrimaryAsync(LegacyHomedConfig(), Actor);
 
         Assert.Equal(AppHomingAutoFlipOutcome.ProbeFailed, outcome);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class AppHomingServiceTests
         var outcome = await _sut.TryAutoFlipToPrimaryAsync(LegacyHomedConfig(), Actor);
 
         Assert.Equal(AppHomingAutoFlipOutcome.ProbeTransient, outcome);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public class AppHomingServiceTests
         var outcome = await _sut.TryAutoFlipToPrimaryAsync(LegacyHomedConfig(), Actor);
 
         Assert.Equal(AppHomingAutoFlipOutcome.NotEligible, outcome);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     // ── FlipAsync ───────────────────────────────────────────────────────────
@@ -251,7 +251,7 @@ public class AppHomingServiceTests
 
         await _sut.FlipAsync(TenantId, PrimaryId, Actor, "manual-ga");
 
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
         _detectorMock.Verify(x => x.InvalidateTenant(It.IsAny<string>()), Times.Never);
         Assert.Empty(_savedOpsEvents);
     }
@@ -267,7 +267,7 @@ public class AppHomingServiceTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => _sut.FlipAsync(TenantId, PrimaryId, Actor, "manual-ga"));
 
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
         _detectorMock.Verify(x => x.InvalidateTenant(It.IsAny<string>()), Times.Never);
         Assert.Empty(_savedOpsEvents);
     }
@@ -283,7 +283,7 @@ public class AppHomingServiceTests
 
         // The null-homing invariant: legacy is represented as null, never as the legacy GUID.
         _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.Is<TenantConfiguration>(c =>
-            c.HomedAppClientId == null)), Times.Once);
+            c.HomedAppClientId == null), It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         _detectorMock.Verify(x => x.InvalidateTenant(TenantId), Times.Once);
     }
 }

--- a/src/Backend/AutopilotMonitor.Functions.Tests/AuthFunctionSideEffectTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/AuthFunctionSideEffectTests.cs
@@ -97,7 +97,7 @@ public class AuthFunctionSideEffectTests
 
         // Default: all fire-and-forget calls succeed
         _tenantConfigMock
-            .Setup(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()))
+            .Setup(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
         _telegramMock
             .Setup(x => x.SendNewTenantSignupAsync(It.IsAny<string>(), It.IsAny<string>()))
@@ -132,7 +132,7 @@ public class AuthFunctionSideEffectTests
         // OnboardedBy is the immutable copy of the first-login UPN that auto-promote on
         // preview approval reads — UpdatedBy may later be clobbered by background syncs.
         Assert.Equal(Upn, config.OnboardedBy);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(config), Times.Once);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(config, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         _telegramMock.Verify(x => x.SendNewTenantSignupAsync(TenantId, Upn), Times.Once);
         _globalNotificationMock.Verify(x => x.CreateNotificationAsync(
             "preview_signup", "New Tenant Signup",
@@ -176,8 +176,8 @@ public class AuthFunctionSideEffectTests
         await _sut.HandleAuthClientIdTrackingAsync(cached, TenantId, $"api://{PrimaryAppId}");
 
         // The FRESH entity was mutated and saved — the flip survives, the stale view is discarded.
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(fresh), Times.Once);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(cached), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(fresh, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(cached, It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
         Assert.Equal(PrimaryAppId, fresh.HomedAppClientId);
         Assert.Equal(PrimaryAppId, fresh.LastAuthClientId);
         Assert.NotNull(fresh.LastAuthClientIdSince);
@@ -200,7 +200,7 @@ public class AuthFunctionSideEffectTests
 
         await _sut.HandleAuthClientIdTrackingAsync(cached, TenantId, PrimaryAppId);
 
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -214,7 +214,7 @@ public class AuthFunctionSideEffectTests
         await _sut.HandleAuthClientIdTrackingAsync(cached, TenantId, $"api://{PrimaryAppId}");
 
         _tenantConfigMock.Verify(x => x.GetConfigurationFreshAsync(It.IsAny<string>()), Times.Never);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -239,7 +239,7 @@ public class AuthFunctionSideEffectTests
 
         await _sut.HandleNewTenantDomainAsync(config, TenantId, Upn);
 
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
         _telegramMock.Verify(x => x.SendNewTenantSignupAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
@@ -251,7 +251,7 @@ public class AuthFunctionSideEffectTests
 
         await _sut.HandleNewTenantDomainAsync(config, TenantId, "");
 
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -262,7 +262,7 @@ public class AuthFunctionSideEffectTests
 
         await _sut.HandleNewTenantDomainAsync(config, TenantId, "nodomain");
 
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -279,7 +279,7 @@ public class AuthFunctionSideEffectTests
         await _sut.HandleNewTenantDomainAsync(config, TenantId, Upn);
 
         // SaveConfig should still have been called before the fire-and-forget
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(config), Times.Once);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(config, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
     }
 
     // -------------------------------------------------------------------------
@@ -300,7 +300,7 @@ public class AuthFunctionSideEffectTests
         Assert.Null(config.DisabledReason);
         Assert.Null(config.DisabledUntil);
         Assert.Equal("System (auto-re-enable)", config.UpdatedBy);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(config), Times.Once);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(config, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
     }
 
     [Fact]
@@ -313,7 +313,7 @@ public class AuthFunctionSideEffectTests
         await _sut.HandleAutoReEnableAsync(config, TenantId);
 
         Assert.True(config.Disabled);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -324,7 +324,7 @@ public class AuthFunctionSideEffectTests
 
         await _sut.HandleAutoReEnableAsync(config, TenantId);
 
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -337,7 +337,7 @@ public class AuthFunctionSideEffectTests
         await _sut.HandleAutoReEnableAsync(config, TenantId);
 
         Assert.True(config.Disabled);
-        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        _tenantConfigMock.Verify(x => x.SaveConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     // -------------------------------------------------------------------------

--- a/src/Backend/AutopilotMonitor.Functions.Tests/ConfigBackupHookTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/ConfigBackupHookTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.DataAccess.TableStorage;
+using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared;
+using AutopilotMonitor.Shared.DataAccess;
+using AutopilotMonitor.Shared.Models;
+using Azure;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// The universal pre-write snapshot hook in <see cref="TableConfigRepository"/>:
+/// every overwriting save of a TenantConfiguration/AdminConfiguration row must first
+/// snapshot the stored row into ConfigurationBackups — except row creations and
+/// noise-only changes — and a backup-storage failure must never break the save (fail-soft).
+/// </summary>
+public class ConfigBackupHookTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+
+    private sealed class Harness
+    {
+        public TableConfigRepository Sut { get; }
+        public Mock<TableClient> Table { get; } = new();
+        public Mock<IConfigBackupRepository> Backup { get; } = new();
+        public List<TableEntity> Upserts { get; } = new();
+
+        public Harness(TableEntity? stored)
+        {
+            if (stored == null)
+            {
+                Table.Setup(c => c.GetEntityAsync<TableEntity>(
+                        It.IsAny<string>(), It.IsAny<string>(),
+                        It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new RequestFailedException(404, "Not Found", "ResourceNotFound", null));
+            }
+            else
+            {
+                Table.Setup(c => c.GetEntityAsync<TableEntity>(
+                        It.IsAny<string>(), It.IsAny<string>(),
+                        It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(stored, Mock.Of<Response>()));
+            }
+
+            Table.Setup(c => c.UpsertEntityAsync(
+                    It.IsAny<TableEntity>(), It.IsAny<TableUpdateMode>(), It.IsAny<CancellationToken>()))
+                .Returns<TableEntity, TableUpdateMode, CancellationToken>((e, _, _) =>
+                {
+                    Upserts.Add(e);
+                    return Task.FromResult(Mock.Of<Response>());
+                });
+
+            var serviceClient = new Mock<TableServiceClient>();
+            serviceClient.Setup(c => c.GetTableClient(It.IsAny<string>())).Returns(Table.Object);
+
+            Sut = new TableConfigRepository(
+                new TableStorageService(serviceClient.Object, NullLogger<TableStorageService>.Instance),
+                Backup.Object,
+                NullLogger<TableConfigRepository>.Instance);
+        }
+    }
+
+    private static TenantConfiguration StoredConfig()
+    {
+        var config = TenantConfiguration.CreateDefault(TenantId);
+        config.DomainName = "contoso.com";
+        config.UpdatedBy = "admin@contoso.com";
+        config.DataRetentionDays = 30;
+        config.TeamsWebhookUrl = "https://contoso.webhook.office.com/hook";
+        return config;
+    }
+
+    /// <summary>
+    /// Mirrors production: every real writer round-trips the STORED row (read-modify-write),
+    /// so time-stamped fields like OnboardedAt match the stored values exactly. Constructing
+    /// a second CreateDefault instead would fabricate an OnboardedAt diff that cannot occur.
+    /// </summary>
+    private static TenantConfiguration RoundtripClone(TenantConfiguration stored)
+        => TableConfigRepository.ConvertFromTenantTableEntity(
+            TableConfigRepository.ConvertToTenantTableEntity(stored));
+
+    [Fact]
+    public async Task RealChange_SnapshotsStoredRow_ThenSaves_ThenPrunes()
+    {
+        var stored = StoredConfig();
+        var harness = new Harness(TableConfigRepository.ConvertToTenantTableEntity(stored));
+
+        var incoming = RoundtripClone(stored);
+        incoming.DataRetentionDays = 90;
+        incoming.UpdatedBy = "ga@operator.example";
+
+        ConfigBackupEntry? snapshot = null;
+        harness.Backup
+            .Setup(b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<ConfigBackupEntry, CancellationToken>((e, _) => snapshot = e)
+            .Returns(Task.CompletedTask);
+
+        var saved = await harness.Sut.SaveTenantConfigurationAsync(incoming, "portal-put", "test change");
+
+        Assert.True(saved);
+        Assert.Single(harness.Upserts); // the config row itself
+        Assert.NotNull(snapshot);
+        Assert.Equal(TenantId, snapshot!.PartitionKey);
+        Assert.Equal("portal-put", snapshot.Source);
+        Assert.Equal("test change", snapshot.Reason);
+        Assert.Equal("ga@operator.example", snapshot.ChangedBy); // identity about to write
+        // The snapshot holds the STORED row (retention 30), not the incoming one.
+        Assert.Contains("\"DataRetentionDays\":30", snapshot.EntityJson);
+        // Raw secrets ARE in EntityJson (full-fidelity restore source)…
+        Assert.Contains("contoso.webhook.office.com", snapshot.EntityJson);
+        // …but the advisory diff masks them by property-name heuristics (ConfigDiffHelper).
+        Assert.DoesNotContain("contoso.webhook.office.com", snapshot.DiffJson ?? string.Empty);
+        harness.Backup.Verify(
+            b => b.PruneAsync(TenantId, Constants.ConfigBackupKeepCount, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RowCreation_NoExistingRow_NoSnapshot()
+    {
+        var harness = new Harness(stored: null);
+
+        var saved = await harness.Sut.SaveTenantConfigurationAsync(StoredConfig(), "portal-put", null);
+
+        Assert.True(saved);
+        Assert.Single(harness.Upserts);
+        harness.Backup.Verify(
+            b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        harness.Backup.Verify(
+            b => b.PruneAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NoiseOnlyChange_AuthClientIdFlip_NoSnapshot()
+    {
+        var stored = StoredConfig();
+        var harness = new Harness(TableConfigRepository.ConvertToTenantTableEntity(stored));
+
+        // The auth-side-effect write: only LastAuthClientId/Since + bookkeeping move.
+        var incoming = RoundtripClone(stored);
+        incoming.LastAuthClientId = "886ab5e2-6144-442c-80cc-9b28e0667731";
+        incoming.LastAuthClientIdSince = DateTime.UtcNow;
+        incoming.LastUpdated = DateTime.UtcNow;
+        incoming.UpdatedBy = "System (auth)";
+
+        var saved = await harness.Sut.SaveTenantConfigurationAsync(incoming, "auth", null);
+
+        Assert.True(saved); // the save itself still goes through
+        Assert.Single(harness.Upserts);
+        harness.Backup.Verify(
+            b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NoOpSave_IdenticalContent_NoSnapshot()
+    {
+        var stored = StoredConfig();
+        var harness = new Harness(TableConfigRepository.ConvertToTenantTableEntity(stored));
+
+        var saved = await harness.Sut.SaveTenantConfigurationAsync(RoundtripClone(stored), "portal-put", null);
+
+        Assert.True(saved);
+        harness.Backup.Verify(
+            b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BackupStorageFailure_IsFailSoft_SaveStillSucceeds()
+    {
+        var stored = StoredConfig();
+        var harness = new Harness(TableConfigRepository.ConvertToTenantTableEntity(stored));
+        harness.Backup
+            .Setup(b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RequestFailedException(503, "backup table throttled"));
+
+        var incoming = RoundtripClone(stored);
+        incoming.DataRetentionDays = 90;
+
+        var saved = await harness.Sut.SaveTenantConfigurationAsync(incoming, "portal-put", null);
+
+        Assert.True(saved);
+        Assert.Single(harness.Upserts); // the config write went through regardless
+    }
+
+    [Fact]
+    public async Task LegacyOneArgOverload_StillSnapshots_WithUnknownSource()
+    {
+        var stored = StoredConfig();
+        var harness = new Harness(TableConfigRepository.ConvertToTenantTableEntity(stored));
+
+        ConfigBackupEntry? snapshot = null;
+        harness.Backup
+            .Setup(b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<ConfigBackupEntry, CancellationToken>((e, _) => snapshot = e)
+            .Returns(Task.CompletedTask);
+
+        var incoming = RoundtripClone(stored);
+        incoming.DataRetentionDays = 90;
+        await harness.Sut.SaveTenantConfigurationAsync(incoming);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal("unknown", snapshot!.Source);
+    }
+
+    [Fact]
+    public async Task AdminConfigSave_SnapshotsUnderGlobalConfigPartition()
+    {
+        var stored = new AdminConfiguration
+        {
+            UpdatedBy = "ga@operator.example",
+            GlobalRateLimitRequestsPerMinute = 100,
+        };
+        var harness = new Harness(TableConfigRepository.ConvertToAdminTableEntity(stored));
+
+        ConfigBackupEntry? snapshot = null;
+        harness.Backup
+            .Setup(b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<ConfigBackupEntry, CancellationToken>((e, _) => snapshot = e)
+            .Returns(Task.CompletedTask);
+
+        var incoming = new AdminConfiguration
+        {
+            UpdatedBy = "ga@operator.example",
+            GlobalRateLimitRequestsPerMinute = 200,
+        };
+
+        var saved = await harness.Sut.SaveAdminConfigurationAsync(incoming);
+
+        Assert.True(saved);
+        Assert.NotNull(snapshot);
+        Assert.Equal("GlobalConfig", snapshot!.PartitionKey);
+        Assert.Equal("admin-config", snapshot.Source);
+        harness.Backup.Verify(
+            b => b.PruneAsync("GlobalConfig", Constants.ConfigBackupKeepCount, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/ConfigBackupRepositoryTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/ConfigBackupRepositoryTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.DataAccess.TableStorage;
+using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared.Models;
+using Azure;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// TableConfigBackupRepository: Store↔Map roundtrip (project rule "table-serialization"),
+/// reverse-ticks RowKey ordering (newest-first), and prune-beyond-keep semantics.
+/// </summary>
+public class ConfigBackupRepositoryTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+
+    private sealed class Harness
+    {
+        public TableConfigBackupRepository Sut { get; }
+        public Mock<TableClient> Table { get; } = new();
+        public List<TableEntity> Upserts { get; } = new();
+        public List<(string Pk, string Rk)> Deletes { get; } = new();
+
+        public Harness()
+        {
+            Table.Setup(c => c.UpsertEntityAsync(
+                    It.IsAny<TableEntity>(), It.IsAny<TableUpdateMode>(), It.IsAny<CancellationToken>()))
+                .Returns<TableEntity, TableUpdateMode, CancellationToken>((e, _, _) =>
+                {
+                    Upserts.Add(e);
+                    return Task.FromResult(Mock.Of<Response>());
+                });
+            Table.Setup(c => c.DeleteEntityAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ETag>(), It.IsAny<CancellationToken>()))
+                .Returns<string, string, ETag, CancellationToken>((pk, rk, _, _) =>
+                {
+                    Deletes.Add((pk, rk));
+                    return Task.FromResult(Mock.Of<Response>());
+                });
+
+            var serviceClient = new Mock<TableServiceClient>();
+            serviceClient.Setup(c => c.GetTableClient(It.IsAny<string>())).Returns(Table.Object);
+            Sut = new TableConfigBackupRepository(
+                new TableStorageService(serviceClient.Object, NullLogger<TableStorageService>.Instance),
+                NullLogger<TableConfigBackupRepository>.Instance);
+        }
+
+        public void SetupQuery(params TableEntity[] rows)
+        {
+            var page = Page<TableEntity>.FromValues(rows, continuationToken: null, Mock.Of<Response>());
+            Table.Setup(c => c.QueryAsync<TableEntity>(
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                .Returns(AsyncPageable<TableEntity>.FromPages(new[] { page }));
+        }
+    }
+
+    private static ConfigBackupEntry Entry(string rowKey = "0001_abc") => new()
+    {
+        PartitionKey = TenantId,
+        RowKey = rowKey,
+        TenantId = TenantId,
+        EntityJson = "{\"DomainName\":\"contoso.com\"}",
+        ChangedBy = "ga@operator.example",
+        Source = "mcp-patch",
+        Reason = "retention bump",
+        DiffJson = "{\"DataRetentionDays\":\"30 \\u2192 90\"}",
+        BackupTakenAt = new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc),
+    };
+
+    [Fact]
+    public async Task Roundtrip_StoreAndMap_PreservesEveryField()
+    {
+        var harness = new Harness();
+        var entry = Entry();
+
+        await harness.Sut.UpsertAsync(entry);
+        var stored = Assert.Single(harness.Upserts);
+
+        // Feed the stored entity back through the read path (TryGetAsync → Map).
+        harness.Table.Setup(c => c.GetEntityAsync<TableEntity>(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(stored, Mock.Of<Response>()));
+        var mapped = await harness.Sut.TryGetAsync(TenantId, entry.RowKey);
+
+        Assert.NotNull(mapped);
+        Assert.Equal(entry.PartitionKey, mapped!.PartitionKey);
+        Assert.Equal(entry.RowKey, mapped.RowKey);
+        Assert.Equal(entry.TenantId, mapped.TenantId);
+        Assert.Equal(entry.EntityJson, mapped.EntityJson);
+        Assert.Equal(entry.ChangedBy, mapped.ChangedBy);
+        Assert.Equal(entry.Source, mapped.Source);
+        Assert.Equal(entry.Reason, mapped.Reason);
+        Assert.Equal(entry.DiffJson, mapped.DiffJson);
+        Assert.Equal(entry.BackupTakenAt, mapped.BackupTakenAt);
+    }
+
+    [Fact]
+    public void BuildRowKey_LaterTimestamps_SortFirst()
+    {
+        var earlier = TableConfigBackupRepository.BuildRowKey(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc));
+        var later = TableConfigBackupRepository.BuildRowKey(new DateTime(2026, 8, 3, 12, 0, 1, DateTimeKind.Utc));
+
+        // Reverse ticks: the LATER backup gets the LEXICOGRAPHICALLY SMALLER RowKey, so
+        // Azure's RowKey-ascending partition scan returns newest-first.
+        Assert.True(string.CompareOrdinal(later, earlier) < 0);
+    }
+
+    [Fact]
+    public void BuildRowKey_SameTick_DistinctViaGuidSuffix()
+    {
+        var at = new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc);
+        Assert.NotEqual(
+            TableConfigBackupRepository.BuildRowKey(at),
+            TableConfigBackupRepository.BuildRowKey(at));
+    }
+
+    [Fact]
+    public async Task Prune_DeletesEverythingBeyondKeep_InScanOrder()
+    {
+        var harness = new Harness();
+        // Scan order = RowKey ascending = newest first (reverse ticks). keep=2 must
+        // delete rows 3 and 4, never the two newest.
+        harness.SetupQuery(
+            new TableEntity(TenantId, "0001_newest"),
+            new TableEntity(TenantId, "0002_second"),
+            new TableEntity(TenantId, "0003_old"),
+            new TableEntity(TenantId, "0004_oldest"));
+
+        var deleted = await harness.Sut.PruneAsync(TenantId, keep: 2);
+
+        Assert.Equal(2, deleted);
+        Assert.Equal(new[] { "0003_old", "0004_oldest" }, harness.Deletes.Select(d => d.Rk).ToArray());
+    }
+
+    [Fact]
+    public async Task Prune_WithinKeep_DeletesNothing()
+    {
+        var harness = new Harness();
+        harness.SetupQuery(
+            new TableEntity(TenantId, "0001_newest"),
+            new TableEntity(TenantId, "0002_second"));
+
+        var deleted = await harness.Sut.PruneAsync(TenantId, keep: 2);
+
+        Assert.Equal(0, deleted);
+        Assert.Empty(harness.Deletes);
+    }
+
+    [Fact]
+    public async Task ListByPartition_CapsAtMax()
+    {
+        var harness = new Harness();
+        harness.SetupQuery(
+            new TableEntity(TenantId, "0001"),
+            new TableEntity(TenantId, "0002"),
+            new TableEntity(TenantId, "0003"));
+
+        var listed = await harness.Sut.ListByPartitionAsync(TenantId, max: 2);
+
+        Assert.Equal(2, listed.Count);
+        Assert.Equal("0001", listed[0].RowKey);
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/ConfigRedactionTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/ConfigRedactionTests.cs
@@ -192,4 +192,37 @@ public class ConfigRedactionTests
         // Operator/Viewer arrives with IsTenantAdmin=false ⇒ always the redacted copy.
         => Assert.False(GetTenantConfigurationFunction.CanViewSecrets(
             new RequestContext { UserRole = role, TenantId = TenantA, TargetTenantId = TenantA }));
+
+    // ── ?view=redacted opt-in (MCP get_tenant_config): forces redaction even for GA ──
+
+    [Fact]
+    public void ShouldRedact_GlobalAdmin_ViewRedacted_True()
+        => Assert.True(GetTenantConfigurationFunction.ShouldRedact(
+            new RequestContext { IsGlobalAdmin = true, TenantId = TenantA, TargetTenantId = TenantB },
+            "?view=redacted"));
+
+    [Fact]
+    public void ShouldRedact_OwnTenantAdmin_ViewRedacted_True()
+        => Assert.True(GetTenantConfigurationFunction.ShouldRedact(
+            new RequestContext { IsTenantAdmin = true, TenantId = TenantA, TargetTenantId = TenantA },
+            "?view=redacted"));
+
+    [Fact]
+    public void ShouldRedact_GlobalAdmin_NoParam_False()
+        // Without the opt-in the GA clearance stands — the portal Settings UI depends on it.
+        => Assert.False(GetTenantConfigurationFunction.ShouldRedact(
+            new RequestContext { IsGlobalAdmin = true, TenantId = TenantA, TargetTenantId = TenantB },
+            ""));
+
+    [Fact]
+    public void ShouldRedact_GlobalAdmin_OtherViewValue_False()
+        => Assert.False(GetTenantConfigurationFunction.ShouldRedact(
+            new RequestContext { IsGlobalAdmin = true, TenantId = TenantA, TargetTenantId = TenantB },
+            "?view=full"));
+
+    [Fact]
+    public void ShouldRedact_ReaderWithoutClearance_AlwaysTrue_RegardlessOfParam()
+        => Assert.True(GetTenantConfigurationFunction.ShouldRedact(
+            new RequestContext { IsGlobalReader = true, TenantId = TenantA, TargetTenantId = TenantB },
+            "?view=full"));
 }

--- a/src/Backend/AutopilotMonitor.Functions.Tests/CriticalTableBackupServiceTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/CriticalTableBackupServiceTests.cs
@@ -47,7 +47,7 @@ public class CriticalTableBackupServiceTests
 
         Assert.Equal(BackupOutcome.Success, result.Outcome);
         Assert.True(store.ManifestWritten, "manifest must be written LAST");
-        Assert.Equal(16, result.Manifest.Tables.Count);   // critical-tables catalog count (incl. DelegatedAdmins)
+        Assert.Equal(17, result.Manifest.Tables.Count);   // critical-tables catalog count (incl. DelegatedAdmins + ConfigurationBackups)
         Assert.All(result.Manifest.Tables, t =>
             Assert.True(t.Status == TableBackupStatus.Ok || t.Status == TableBackupStatus.Empty));
     }

--- a/src/Backend/AutopilotMonitor.Functions.Tests/Offboarding/OffboardingMarkerCleanupFunctionTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/Offboarding/OffboardingMarkerCleanupFunctionTests.cs
@@ -180,10 +180,14 @@ public class OffboardingMarkerCleanupFunctionTests
         Assert.Equal(0, result.TenantConfigsSpared);
         Assert.Equal(0, result.TenantConfigSweepRetries);
 
-        // The sweep ran with the right table + tenant id.
-        Assert.Single(fixture.SafeWipe.WipeCalls);
+        // The sweep ran with the right tables + tenant id: the tombstone itself, plus the
+        // tenant's config-backup partition (a save against the lingering tombstone may have
+        // re-created snapshots after the cascade's bulk wipe).
+        Assert.Equal(2, fixture.SafeWipe.WipeCalls.Count);
         Assert.Equal(Constants.TableNames.TenantConfiguration, fixture.SafeWipe.WipeCalls[0].Table);
         Assert.Equal(TenantId, fixture.SafeWipe.WipeCalls[0].TenantId);
+        Assert.Equal(Constants.TableNames.ConfigurationBackups, fixture.SafeWipe.WipeCalls[1].Table);
+        Assert.Equal(TenantId, fixture.SafeWipe.WipeCalls[1].TenantId);
         Assert.False(fixture.Repo.Markers.ContainsKey(TenantId));
     }
 

--- a/src/Backend/AutopilotMonitor.Functions.Tests/Offboarding/TenantOffboardingHandlerOrderingTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/Offboarding/TenantOffboardingHandlerOrderingTests.cs
@@ -279,6 +279,20 @@ public class TenantOffboardingHandlerOrderingTests
         Assert.Contains(Constants.TableNames.TenantGroups, harness.SafeWipeProbe.PropertyOnlyWipes);
     }
 
+    [Fact]
+    public async Task PostDrain_ExactPartitionWipe_CoversConfigurationBackups()
+    {
+        // Pre-write config snapshots (PK=tenantId) must die with the tenant — the row
+        // contents include webhook URLs and the contact address. The bulk wipe runs
+        // before the final TenantConfiguration delete, so no snapshot can be re-created
+        // afterwards by the cascade itself.
+        var harness = Harness.New();
+
+        await harness.Sut.HandleAsync(harness.Envelope());
+
+        Assert.Contains(Constants.TableNames.ConfigurationBackups, harness.SafeWipeProbe.ExactPartitionWipes);
+    }
+
     // ── Harness (copied minimal — only what these tests need) ───────────────────
 
     private sealed class Harness
@@ -425,12 +439,14 @@ public class TenantOffboardingHandlerOrderingTests
         public int WipeCallCount { get; private set; }
         /// <summary>Table names passed to the property-only (Variant C) wipe — lets tests assert coverage.</summary>
         public List<string> PropertyOnlyWipes { get; } = new();
+        /// <summary>Table names passed to the exact-partition (Variant A) wipe — lets tests assert coverage.</summary>
+        public List<string> ExactPartitionWipes { get; } = new();
         public CountingSafeWipeService() : base(
             new TableStorageService(Mock.Of<TableServiceClient>(), NullLogger<TableStorageService>.Instance),
             new BlobStorageService(new BlobServiceClient("UseDevelopmentStorage=true"),
                 NullLogger<BlobStorageService>.Instance, usesManagedIdentity: false),
             NullLogger<SafeWipeService>.Instance) { }
-        public override Task<int> WipeByExactPartitionAsync(string t, string i, CancellationToken c = default) { WipeCallCount++; return Task.FromResult(0); }
+        public override Task<int> WipeByExactPartitionAsync(string t, string i, CancellationToken c = default) { WipeCallCount++; ExactPartitionWipes.Add(t); return Task.FromResult(0); }
         public override Task<int> WipeByCompositePartitionRangeAsync(string t, string i, CancellationToken c = default) { WipeCallCount++; return Task.FromResult(0); }
         public override Task<int> WipeByDiscriminatorAndTenantPropertyAsync(string t, string d, string i, CancellationToken c = default) { WipeCallCount++; return Task.FromResult(0); }
         public override Task<int> WipeByTenantIdPropertyAsync(string t, string i, CancellationToken c = default) { WipeCallCount++; PropertyOnlyWipes.Add(t); return Task.FromResult(0); }

--- a/src/Backend/AutopilotMonitor.Functions.Tests/PolicyEnforcementMiddlewareTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/PolicyEnforcementMiddlewareTests.cs
@@ -605,6 +605,56 @@ public class PolicyEnforcementMiddlewareTests
         Assert.True(result.Allowed);
     }
 
+    // ── Transactional config patch / backups / revert — GlobalAdminOnly (phase 1) ──
+
+    [Fact]
+    public async Task ConfigFieldPatchRoutes_GlobalAdmin_IsAllowed()
+    {
+        const string upn = "ga@vendor.example";
+        var h = BuildHarness();
+        h.AsGlobalRole(Constants.GlobalRoles.GlobalAdmin);
+
+        foreach (var (method, path) in new[]
+        {
+            ("PATCH", $"/api/config/{TenantB}/fields"),
+            ("GET", $"/api/config/{TenantB}/backups"),
+            ("POST", $"/api/config/{TenantB}/revert"),
+        })
+        {
+            var result = await h.Middleware.DecideAsync(method, path, null, AuthedPrincipal(TenantA, upn));
+            Assert.True(result.Allowed, $"{method} {path} must admit a Global Admin");
+        }
+    }
+
+    [Fact]
+    public async Task ConfigFieldPatchRoutes_TenantAdmin_GlobalReader_Delegated_AreForbidden()
+    {
+        // Phase 1 is deliberately GA-only — even the tenant's OWN admin is denied until the
+        // phase-2 flip to TenantAdminOrGA (+ the caller-tier field deny-list in the service).
+        foreach (var (method, path) in new[]
+        {
+            ("PATCH", $"/api/config/{TenantA}/fields"),
+            ("GET", $"/api/config/{TenantA}/backups"),
+            ("POST", $"/api/config/{TenantA}/revert"),
+        })
+        {
+            var ownAdmin = BuildHarness();
+            ownAdmin.AsTenantAdmin(TenantA, "admin@contoso.com");
+            var adminResult = await ownAdmin.Middleware.DecideAsync(method, path, null, AuthedPrincipal(TenantA, "admin@contoso.com"));
+            Assert.False(adminResult.Allowed, $"{method} {path} must deny a tenant admin in phase 1");
+
+            var reader = BuildHarness();
+            reader.AsGlobalRole(Constants.GlobalRoles.GlobalReader);
+            var readerResult = await reader.Middleware.DecideAsync(method, path, null, AuthedPrincipal(TenantB, "reader@vendor.example"));
+            Assert.False(readerResult.Allowed, $"{method} {path} must deny a read-only Global Reader");
+
+            var delegated = BuildHarness();
+            delegated.AsDelegated(TenantA, Constants.DelegatedRoles.DelegatedAdmin);
+            var delegatedResult = await delegated.Middleware.DecideAsync(method, path, null, AuthedPrincipal(TenantB, "msp@partner.example"));
+            Assert.False(delegatedResult.Allowed, $"{method} {path} must deny a delegated (MSP) admin in phase 1");
+        }
+    }
+
     [Fact]
     public async Task Delegated_OwnHomeTenant_NonMember_IsStillForbidden()
     {

--- a/src/Backend/AutopilotMonitor.Functions.Tests/PolicyEnforcementMiddlewareTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/PolicyEnforcementMiddlewareTests.cs
@@ -672,6 +672,8 @@ public class PolicyEnforcementMiddlewareTests
         Assert.True(result.Allowed); // the delegated read itself is allowed…
         // …but no config row was persisted for the MSP's home tenant A (nor any tenant).
         h.ConfigRepo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        h.ConfigRepo.Verify(r => r.SaveTenantConfigurationAsync(
+            It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     // ── Phase 2a: delegated single-tenant access to cross-tenant /api/global/* read endpoints ──

--- a/src/Backend/AutopilotMonitor.Functions.Tests/SessionDeletionWorkerTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/SessionDeletionWorkerTests.cs
@@ -483,18 +483,29 @@ public class SessionDeletionWorkerTests
         };
         harness.EnqueueMessage(JsonConvert.SerializeObject(envelope), dequeueCount: 1);
 
-        // Handler hangs for 350ms so the heartbeat task ticks at least 5×.
+        // De-flake (CI: a fixed 350ms handler window raced the 50ms heartbeat timer on loaded
+        // runners — the handler could finish before 3 heartbeats fired, after which the awaited
+        // condition can never become true). Instead the handler holds the message in-flight
+        // UNTIL the heartbeats have been observed: the heartbeat task ticks for as long as the
+        // handler runs, so the condition is reached deterministically regardless of scheduler
+        // jitter. A genuinely broken heartbeat leaves the loop to the worker's cancellation at
+        // RunUntilAsync's ceiling, and the Times.AtLeast(3) below fails as intended.
         harness.HandlerMock.Setup(h => h.HandleAsync(
                 It.IsAny<SessionDeletionEnvelope>(), It.IsAny<CancellationToken>()))
             .Returns(async (SessionDeletionEnvelope _, CancellationToken ct) =>
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(350), ct);
+                // Own deadline besides ct: if the heartbeat were broken AND shutdown never
+                // cancelled the handler token, the test must still terminate (and then fail
+                // on the verify) instead of hanging in StopAsync.
+                var handlerDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+                while (!ct.IsCancellationRequested && harness.HeartbeatCount() < 3 && DateTime.UtcNow < handlerDeadline)
+                    await Task.Delay(10, CancellationToken.None);
             });
 
         await harness.RunUntilAsync(() => harness.HeartbeatCount() >= 3);
 
-        // Heartbeat called at least 3× while the handler was busy (350ms / 50ms ≈ 7, minus a few
-        // due to scheduling jitter). One call is enough to prove the heartbeat task is wired.
+        // Heartbeat fired at least 3× while the handler was busy — proves the heartbeat task
+        // is wired and keeps extending visibility for the whole duration of a long handler run.
         harness.MainQueue.Verify(q => q.UpdateMessageAsync(
             It.IsAny<string>(), It.IsAny<string>(),
             It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),

--- a/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigPatchServiceTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigPatchServiceTests.cs
@@ -1,0 +1,525 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.DataAccess.TableStorage;
+using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared;
+using AutopilotMonitor.Shared.DataAccess;
+using AutopilotMonitor.Shared.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// Transactional config patch/revert: field gates, fail-closed backup, CAS retry,
+/// exactly-these-fields verification with automatic rollback, and the phase-2
+/// caller-tier deny-lists. The harness emulates real table CAS semantics (versioned
+/// ETags, conditional replace) so the retry/rollback paths are exercised honestly.
+/// </summary>
+public class TenantConfigPatchServiceTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+    private const string Ga = "ga@operator.example";
+
+    /// <summary>In-memory row with real CAS semantics + optional write-time corruption hook.</summary>
+    private sealed class Harness
+    {
+        public Mock<IConfigRepository> Repo { get; } = new();
+        public Mock<IConfigBackupRepository> Backup { get; } = new();
+        public Mock<IMaintenanceRepository> Maintenance { get; } = new();
+        public TenantConfigPatchService Sut { get; }
+
+        public TenantConfiguration? Current;
+        public int Version = 1;
+        public List<ConfigBackupEntry> Backups { get; } = new();
+        public int ReplaceCalls;
+        /// <summary>Applied to the stored row on every successful replace — simulates serialization drift.</summary>
+        public Func<TenantConfiguration, TenantConfiguration>? CorruptOnWrite;
+        /// <summary>Bumps the version WITHOUT a replace before the Nth replace call — simulates a concurrent writer.</summary>
+        public int? StealEtagBeforeReplaceCall;
+
+        public Harness(TenantConfiguration? stored)
+        {
+            Current = stored;
+
+            Repo.Setup(r => r.GetTenantConfigurationWithEtagAsync(TenantId))
+                .ReturnsAsync(() => Current == null
+                    ? ((TenantConfiguration, string)?)null
+                    : (Clone(Current), $"etag-{Version}"));
+
+            Repo.Setup(r => r.TryReplaceTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string>()))
+                .Returns<TenantConfiguration, string>((config, etag) =>
+                {
+                    ReplaceCalls++;
+                    if (StealEtagBeforeReplaceCall == ReplaceCalls)
+                    {
+                        Version++; // the concurrent writer got there first
+                        StealEtagBeforeReplaceCall = null;
+                    }
+                    if (etag != $"etag-{Version}")
+                        return Task.FromResult(false);
+                    Current = CorruptOnWrite != null ? CorruptOnWrite(Clone(config)) : Clone(config);
+                    Version++;
+                    return Task.FromResult(true);
+                });
+
+            Backup.Setup(b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()))
+                .Callback<ConfigBackupEntry, CancellationToken>((e, _) => Backups.Add(e))
+                .Returns(Task.CompletedTask);
+            Backup.Setup(b => b.ListByPartitionAsync(TenantId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => Backups.AsEnumerable().Reverse().ToList()); // newest first
+            Backup.Setup(b => b.TryGetAsync(TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns<string, string, CancellationToken>((_, id, _) =>
+                    Task.FromResult(Backups.FirstOrDefault(b => b.RowKey == id)));
+
+            Maintenance.Setup(m => m.LogAuditEntryAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>?>()))
+                .ReturnsAsync(true);
+
+            var configService = new TenantConfigurationService(
+                Repo.Object, NullLogger<TenantConfigurationService>.Instance,
+                new MemoryCache(new MemoryCacheOptions()));
+
+            Sut = new TenantConfigPatchService(
+                Repo.Object, Backup.Object, configService, Maintenance.Object,
+                NullLogger<TenantConfigPatchService>.Instance);
+        }
+
+        private static TenantConfiguration Clone(TenantConfiguration c)
+            => JsonConvert.DeserializeObject<TenantConfiguration>(JsonConvert.SerializeObject(c))!;
+    }
+
+    private static TenantConfiguration Stored()
+    {
+        var config = TenantConfiguration.CreateDefault(TenantId);
+        config.DomainName = "contoso.com";
+        config.UpdatedBy = "admin@contoso.com";
+        config.DataRetentionDays = 30;
+        config.TeamsWebhookUrl = "https://contoso.webhook.office.com/hook";
+        return config;
+    }
+
+    private static JObject Fields(params (string Key, object? Value)[] fields)
+    {
+        var o = new JObject();
+        foreach (var (key, value) in fields)
+            o[key] = value == null ? JValue.CreateNull() : JToken.FromObject(value);
+        return o;
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Patch_SingleField_Applies_BacksUp_Verifies_Audits()
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", "retention bump");
+
+        Assert.True(outcome.Success);
+        Assert.Equal(new[] { "DataRetentionDays" }, outcome.AppliedFields);
+        Assert.Equal(90, harness.Current!.DataRetentionDays);
+        Assert.Equal(Ga, harness.Current.UpdatedBy);
+        Assert.NotNull(outcome.BackupId);
+        var backup = Assert.Single(harness.Backups);
+        Assert.Equal("mcp-patch", backup.Source);
+        Assert.Equal("retention bump", backup.Reason);
+        Assert.Contains("\"DataRetentionDays\":30", backup.EntityJson); // snapshot = PRE-write state
+        Assert.True(outcome.MaskedDiff!.ContainsKey("DataRetentionDays"));
+        harness.Maintenance.Verify(m => m.LogAuditEntryAsync(
+            TenantId, "PATCH", "TenantConfiguration", TenantId, Ga,
+            It.Is<Dictionary<string, string>?>(d => d != null && d["BackupId"] == outcome.BackupId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Patch_NullValue_ClearsNullableField()
+    {
+        var stored = Stored();
+        stored.ContactEmail = "ops@contoso.com";
+        var harness = new Harness(stored);
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("contactEmail", null)), Ga, "mcp-patch", null);
+
+        Assert.True(outcome.Success);
+        Assert.Null(harness.Current!.ContactEmail);
+    }
+
+    [Fact]
+    public async Task Patch_NoOp_ValueEqualsStored_NoBackupNoWrite()
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 30)), Ga, "mcp-patch", null);
+
+        Assert.True(outcome.Success);
+        Assert.Empty(outcome.AppliedFields);
+        Assert.Null(outcome.BackupId);
+        Assert.Empty(harness.Backups);
+        Assert.Equal(0, harness.ReplaceCalls);
+    }
+
+    // ── Field gate ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("planTier")]
+    [InlineData("trialExpiresUtc")]
+    [InlineData("homedAppClientId")]
+    [InlineData("lastAuthClientId")]
+    [InlineData("onboardedBy")]
+    [InlineData("tenantId")]
+    [InlineData("domainName")]
+    [InlineData("lastUpdated")]
+    [InlineData("updatedBy")]
+    public async Task Patch_DeniedField_Returns400WithFieldName(string field)
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields((field, "x")), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.InvalidField, outcome.Failure);
+        Assert.Contains(field, outcome.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(harness.Backups);
+        Assert.Equal(0, harness.ReplaceCalls);
+    }
+
+    [Fact]
+    public async Task Patch_UnknownField_Returns400WithFieldName()
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("definitelyNotAField", 1)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.InvalidField, outcome.Failure);
+        Assert.Contains("definitelyNotAField", outcome.Error);
+    }
+
+    [Fact]
+    public async Task Patch_RedactedPlaceholderValue_Rejected()
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("webhookUrl", Constants.RedactedSecretPlaceholder)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.InvalidField, outcome.Failure);
+        Assert.Contains("redacted", outcome.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Patch_GaOnlyField_AllowedForGa_DeniedForTenantAdminTier()
+    {
+        var gaHarness = new Harness(Stored());
+        var gaOutcome = await gaHarness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("bootstrapTokenEnabled", true)), Ga, "mcp-patch", null,
+            TenantConfigCallerTier.GlobalAdmin);
+        Assert.True(gaOutcome.Success);
+
+        foreach (var tier in new[] { TenantConfigCallerTier.TenantAdmin, TenantConfigCallerTier.DelegatedAdmin })
+        {
+            var harness = new Harness(Stored());
+            var outcome = await harness.Sut.ApplyFieldPatchAsync(
+                TenantId, Fields(("bootstrapTokenEnabled", true)), "admin@contoso.com", "api-patch", null, tier);
+            Assert.False(outcome.Success);
+            Assert.Equal(PatchFailure.InvalidField, outcome.Failure);
+        }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Patch_InvalidWebhookUrl_ValidationFails_NoWrite()
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("webhookUrl", "http://169.254.169.254/latest")), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.ValidationFailed, outcome.Failure);
+        Assert.Equal(0, harness.ReplaceCalls);
+        Assert.Empty(harness.Backups);
+    }
+
+    [Fact]
+    public async Task Patch_BadNotificationChannelsJson_ValidationFails()
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("notificationChannelsJson", "{not json")), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.ValidationFailed, outcome.Failure);
+    }
+
+    [Fact]
+    public async Task Patch_UnrestrictedModeWithoutGate_ExplicitError_NotSilentFlip()
+    {
+        var harness = new Harness(Stored()); // gate (UnrestrictedModeEnabled) is false by default
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("unrestrictedMode", true)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.ValidationFailed, outcome.Failure);
+        Assert.Contains("UnrestrictedModeEnabled", outcome.Error);
+        Assert.Equal(0, harness.ReplaceCalls);
+    }
+
+    // ── Storage edges ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Patch_NoConfigRow_NotFound()
+    {
+        var harness = new Harness(stored: null);
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.NotFound, outcome.Failure);
+    }
+
+    [Fact]
+    public async Task Patch_BackupFailure_IsFailClosed_NoWrite()
+    {
+        var harness = new Harness(Stored());
+        harness.Backup.Setup(b => b.UpsertAsync(It.IsAny<ConfigBackupEntry>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("backup table down"));
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.BackupFailed, outcome.Failure);
+        Assert.Equal(0, harness.ReplaceCalls);
+        Assert.Equal(30, harness.Current!.DataRetentionDays); // untouched
+    }
+
+    [Fact]
+    public async Task Patch_CasRace_RetriesAndSucceeds()
+    {
+        var harness = new Harness(Stored());
+        harness.StealEtagBeforeReplaceCall = 1; // first replace loses, retry wins
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", null);
+
+        Assert.True(outcome.Success);
+        Assert.Equal(2, harness.ReplaceCalls);
+        Assert.Equal(90, harness.Current!.DataRetentionDays);
+    }
+
+    [Fact]
+    public async Task Patch_CasRaceEveryAttempt_ReturnsConflict()
+    {
+        var harness = new Harness(Stored());
+        harness.Repo.Setup(r => r.TryReplaceTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string>()))
+            .ReturnsAsync(false); // permanent race
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.WriteConflict, outcome.Failure);
+    }
+
+    // ── Verify + rollback ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Patch_DriftOnWrite_RollsBackToInitial_AndReportsDriftNames()
+    {
+        var harness = new Harness(Stored());
+        // Simulated serialization drift: every write silently zeroes SessionTimeoutHours.
+        // The verify must catch the unexpected field and roll the row back. (The rollback
+        // write itself is also corrupted by the hook, but rollback success is judged by the
+        // CAS result — clear the hook after the first corruption so the rollback restores.)
+        harness.CorruptOnWrite = written =>
+        {
+            harness.CorruptOnWrite = null;
+            written.SessionTimeoutHours = 0;
+            return written;
+        };
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.DriftRolledBack, outcome.Failure);
+        Assert.Contains(outcome.Drift!, d => d.Contains("SessionTimeoutHours"));
+        Assert.NotNull(outcome.BackupId); // pre-write snapshot exists for manual inspection
+        // The row is back at the initial state: retention 30, timeout restored.
+        Assert.Equal(30, harness.Current!.DataRetentionDays);
+        Assert.Equal(Stored().SessionTimeoutHours, harness.Current.SessionTimeoutHours);
+        // No success audit for a rolled-back write.
+        harness.Maintenance.Verify(m => m.LogAuditEntryAsync(
+            It.IsAny<string>(), "PATCH", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<Dictionary<string, string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Patch_DriftAndRollbackLosesRace_ReportsManualRestoreWithBackupId()
+    {
+        var harness = new Harness(Stored());
+        harness.CorruptOnWrite = written => { written.SessionTimeoutHours = 0; return written; };
+        // Every write corrupts — including the rollback attempt — but the decisive part:
+        // steal the ETag before the rollback replace so the rollback itself loses the race.
+        harness.StealEtagBeforeReplaceCall = 2;
+
+        var outcome = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.DriftRollbackFailed, outcome.Failure);
+        Assert.Contains(outcome.BackupId!, outcome.Error);
+    }
+
+    // ── Revert ──────────────────────────────────────────────────────────────
+
+    private async Task<(Harness Harness, string BackupId)> PatchedHarnessAsync()
+    {
+        var harness = new Harness(Stored());
+        var patch = await harness.Sut.ApplyFieldPatchAsync(
+            TenantId, Fields(("dataRetentionDays", 90)), Ga, "mcp-patch", "bump");
+        Assert.True(patch.Success);
+        return (harness, patch.BackupId!);
+    }
+
+    [Fact]
+    public async Task Revert_Latest_RestoresPatchedField_AndBacksUpCurrentFirst()
+    {
+        var (harness, _) = await PatchedHarnessAsync();
+        Assert.Equal(90, harness.Current!.DataRetentionDays);
+
+        var outcome = await harness.Sut.RevertAsync(
+            TenantId, backupId: null, includeProtectedFields: false, Ga, "mcp-revert", null);
+
+        Assert.True(outcome.Success);
+        Assert.Equal(30, harness.Current!.DataRetentionDays); // back to the pre-patch value
+        Assert.Equal(2, harness.Backups.Count); // revert snapshotted the 90-state first
+        Assert.Contains("\"DataRetentionDays\":90", harness.Backups[1].EntityJson);
+        harness.Maintenance.Verify(m => m.LogAuditEntryAsync(
+            TenantId, "REVERT", "TenantConfiguration", TenantId, Ga,
+            It.IsAny<Dictionary<string, string>?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Revert_ByBackupId_UsesThatSnapshot()
+    {
+        var (harness, backupId) = await PatchedHarnessAsync();
+
+        var outcome = await harness.Sut.RevertAsync(
+            TenantId, backupId, includeProtectedFields: false, Ga, "mcp-revert", null);
+
+        Assert.True(outcome.Success);
+        Assert.Equal(30, harness.Current!.DataRetentionDays);
+    }
+
+    [Fact]
+    public async Task Revert_PreservesProtectedFields_ByDefault()
+    {
+        var (harness, backupId) = await PatchedHarnessAsync();
+        // Plan + homing changed AFTER the snapshot (via their dedicated flows).
+        harness.Current!.PlanTier = "enterprise";
+        harness.Current.HomedAppClientId = "886ab5e2-6144-442c-80cc-9b28e0667731";
+
+        var outcome = await harness.Sut.RevertAsync(
+            TenantId, backupId, includeProtectedFields: false, Ga, "mcp-revert", null);
+
+        Assert.True(outcome.Success);
+        Assert.Equal(30, harness.Current!.DataRetentionDays);      // reverted
+        Assert.Equal("enterprise", harness.Current.PlanTier);      // protected — kept current
+        Assert.Equal("886ab5e2-6144-442c-80cc-9b28e0667731", harness.Current.HomedAppClientId);
+    }
+
+    [Fact]
+    public async Task Revert_IncludeProtectedFields_RestoresThemToo()
+    {
+        var (harness, backupId) = await PatchedHarnessAsync();
+        harness.Current!.PlanTier = "enterprise";
+
+        var outcome = await harness.Sut.RevertAsync(
+            TenantId, backupId, includeProtectedFields: true, Ga, "mcp-revert", null);
+
+        Assert.True(outcome.Success);
+        Assert.Equal(Stored().PlanTier, harness.Current!.PlanTier); // snapshot value restored
+    }
+
+    [Fact]
+    public async Task Revert_NoBackups_NotFound()
+    {
+        var harness = new Harness(Stored());
+
+        var outcome = await harness.Sut.RevertAsync(
+            TenantId, backupId: null, includeProtectedFields: false, Ga, "mcp-revert", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.NotFound, outcome.Failure);
+    }
+
+    [Fact]
+    public async Task Revert_UnknownBackupId_NotFound()
+    {
+        var (harness, _) = await PatchedHarnessAsync();
+
+        var outcome = await harness.Sut.RevertAsync(
+            TenantId, "does-not-exist", includeProtectedFields: false, Ga, "mcp-revert", null);
+
+        Assert.False(outcome.Success);
+        Assert.Equal(PatchFailure.NotFound, outcome.Failure);
+    }
+
+    // ── Rehydration roundtrip (serialization-drift canary) ─────────────────
+
+    [Fact]
+    public void RehydrateEntity_Roundtrip_ProducesIdenticalModel()
+    {
+        var original = Stored();
+        original.ContactEmail = "ops@contoso.com";
+        original.TrialExpiresUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+        original.LastAuthClientIdSince = new DateTime(2026, 7, 31, 18, 3, 0, DateTimeKind.Utc);
+        original.CustomRateLimitRequestsPerMinute = 42;
+
+        // Snapshot exactly as the backup hook does, then rehydrate and re-map.
+        var snapshot = TableConfigRepository.BuildBackupEntry(
+            TableConfigRepository.ConvertToTenantTableEntity(original),
+            TenantId, Ga, "test", null, null);
+        var rehydrated = TableConfigRepository.ConvertFromTenantTableEntity(
+            TenantConfigPatchService.RehydrateTenantConfigEntity(snapshot.EntityJson, TenantId));
+
+        var diff = AutopilotMonitor.Functions.Helpers.ConfigPropertyComparer
+            .GetChangedPropertyNames(original, rehydrated);
+        Assert.True(diff.Count == 0, "Rehydration drift: " + string.Join(", ", diff));
+    }
+
+    [Fact]
+    public void RehydrateEntity_DateLookingStringField_StaysString()
+    {
+        var original = Stored();
+        original.DisabledReason = "2026-08-03T12:00:00+00:00"; // adversarial: a string that parses as a date
+
+        var snapshot = TableConfigRepository.BuildBackupEntry(
+            TableConfigRepository.ConvertToTenantTableEntity(original),
+            TenantId, Ga, "test", null, null);
+        var rehydrated = TableConfigRepository.ConvertFromTenantTableEntity(
+            TenantConfigPatchService.RehydrateTenantConfigEntity(snapshot.EntityJson, TenantId));
+
+        Assert.Equal(original.DisabledReason, rehydrated.DisabledReason);
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigurationServiceReadSemanticsTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigurationServiceReadSemanticsTests.cs
@@ -109,7 +109,7 @@ public sealed class TenantConfigurationServiceReadSemanticsTests
     public async Task SaveConfigurationAsync_RepoReportsFalse_Throws()
     {
         var (service, repo) = Build();
-        repo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        repo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(false);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -125,7 +125,7 @@ public sealed class TenantConfigurationServiceReadSemanticsTests
         var (service, repo) = Build();
         var stored = new TenantConfiguration { TenantId = TenantId, PlanTier = "free", UpdatedBy = "x" };
         repo.Setup(r => r.GetTenantConfigurationAsync(TenantId)).ReturnsAsync(stored);
-        repo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        repo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(false);
 
         var cached = await service.GetConfigurationIfExistsAsync(TenantId);
@@ -144,7 +144,7 @@ public sealed class TenantConfigurationServiceReadSemanticsTests
         var (service, repo) = Build();
         repo.Setup(r => r.GetTenantConfigurationAsync(TenantId))
             .ReturnsAsync(new TenantConfiguration { TenantId = TenantId, UpdatedBy = "x" });
-        repo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        repo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(true);
 
         await service.GetConfigurationIfExistsAsync(TenantId); // prime cache

--- a/src/Backend/AutopilotMonitor.Functions.Tests/TenantContactEmailTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/TenantContactEmailTests.cs
@@ -188,6 +188,8 @@ public class TenantContactEmailTests
         await service.TrySeedContactEmailAsync(TenantId, "ops@contoso.com");
 
         repo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        repo.Verify(r => r.SaveTenantConfigurationAsync(
+            It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -285,6 +287,7 @@ public class TenantContactEmailTests
 
             Sut = new TableConfigRepository(
                 new TableStorageService(serviceClient.Object, NullLogger<TableStorageService>.Instance),
+                Mock.Of<IConfigBackupRepository>(),
                 NullLogger<TableConfigRepository>.Instance);
         }
     }

--- a/src/Backend/AutopilotMonitor.Functions.Tests/TenantEntitlementServiceTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/TenantEntitlementServiceTests.cs
@@ -87,6 +87,8 @@ public class TenantEntitlementServiceTests
         var (svc, repo) = Build(config: null);
         await svc.GetEditionAsync(TenantId);
         repo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        repo.Verify(r => r.SaveTenantConfigurationAsync(
+            It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]

--- a/src/Backend/AutopilotMonitor.Functions.Tests/TenantOffboardFunctionTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/TenantOffboardFunctionTests.cs
@@ -641,8 +641,8 @@ public sealed class TenantOffboardFunctionTests
         configRepo.Setup(r => r.GetTenantConfigurationAsync(TenantId)).ReturnsAsync(existing);
 
         TenantConfiguration? saved = null;
-        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
-            .Callback<TenantConfiguration>(c => saved = c)
+        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<TenantConfiguration, string?, string?>((c, _, _) => saved = c)
             .ReturnsAsync(true);
 
         // Seed cache with stale "Disabled=false" entry so we can prove invalidation.
@@ -671,7 +671,7 @@ public sealed class TenantOffboardFunctionTests
         await sut.EnsureTenantDisabledAsync(TenantId, "alice@contoso.com");
 
         // Idempotent: no Save thrash on resume-clicks while the marker is already in flight.
-        configRepo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        configRepo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -694,7 +694,7 @@ public sealed class TenantOffboardFunctionTests
         var (sut, configRepo, _, _) = BuildWithConfigService();
         configRepo.Setup(r => r.GetTenantConfigurationAsync(TenantId))
             .ReturnsAsync(TenantConfiguration.CreateDefault(TenantId));
-        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ThrowsAsync(new InvalidOperationException("storage save failed"));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -713,8 +713,8 @@ public sealed class TenantOffboardFunctionTests
             .ReturnsAsync((TenantConfiguration?)null);
 
         TenantConfiguration? saved = null;
-        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
-            .Callback<TenantConfiguration>(c => saved = c)
+        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<TenantConfiguration, string?, string?>((c, _, _) => saved = c)
             .ReturnsAsync(true);
 
         await sut.EnsureTenantDisabledAsync(TenantId, "alice@contoso.com");
@@ -736,7 +736,7 @@ public sealed class TenantOffboardFunctionTests
         var (sut, configRepo, _, _) = BuildWithConfigService();
         configRepo.Setup(r => r.GetTenantConfigurationAsync(TenantId))
             .ReturnsAsync(TenantConfiguration.CreateDefault(TenantId));
-        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(false);  // transient storage rejection — NOT a throw.
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -752,7 +752,7 @@ public sealed class TenantOffboardFunctionTests
         var (sut, configRepo, _, _) = BuildWithConfigService();
         configRepo.Setup(r => r.GetTenantConfigurationAsync(TenantId))
             .ReturnsAsync((TenantConfiguration?)null);
-        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(false);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -771,7 +771,7 @@ public sealed class TenantOffboardFunctionTests
         var result = await sut.EnsureTenantDisabledAsync(TenantId, "alice@contoso.com");
 
         Assert.Equal(TenantOffboardFunction.EnsureDisabledOutcome.AlreadyTombstone, result.Outcome);
-        configRepo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        configRepo.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
     [Fact]
@@ -781,7 +781,7 @@ public sealed class TenantOffboardFunctionTests
         var existing = TenantConfiguration.CreateDefault(TenantId);
         existing.Disabled = false;
         configRepo.Setup(r => r.GetTenantConfigurationAsync(TenantId)).ReturnsAsync(existing);
-        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        configRepo.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(true);
 
         var result = await sut.EnsureTenantDisabledAsync(TenantId, "alice@contoso.com");
@@ -832,7 +832,7 @@ public sealed class TenantOffboardFunctionTests
         notYetDisabled.Disabled = false;
         configRepoMock.Setup(r => r.GetTenantConfigurationAsync(It.IsAny<string>()))
             .ReturnsAsync(notYetDisabled);
-        configRepoMock.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()))
+        configRepoMock.Setup(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(true);
 
         var cache = new MemoryCache(new MemoryCacheOptions());
@@ -1044,6 +1044,6 @@ public sealed class TenantOffboardFunctionTests
         Assert.Equal(originalEarliestProcessingAt, historyAfter.EarliestProcessingAt);
 
         // No Save call (the tombstone was already correct).
-        configRepoMock.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>()), Times.Never);
+        configRepoMock.Verify(r => r.SaveTenantConfigurationAsync(It.IsAny<TenantConfiguration>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 }

--- a/src/Backend/AutopilotMonitor.Functions/DataAccess/DataAccessServiceExtensions.cs
+++ b/src/Backend/AutopilotMonitor.Functions/DataAccess/DataAccessServiceExtensions.cs
@@ -53,6 +53,10 @@ namespace AutopilotMonitor.Functions.DataAccess
             // surfaced via the Global Admin /admin/customs-archive page.
             services.AddSingleton<ITenantCustomsArchiveRepository, TableTenantCustomsArchiveRepository>();
 
+            // Pre-write snapshots of TenantConfiguration/AdminConfiguration rows;
+            // constructor dependency of TableConfigRepository's save hook.
+            services.AddSingleton<IConfigBackupRepository, TableConfigBackupRepository>();
+
             // Graph add-on permission feature: per-tenant cache of Intune script display names.
             services.AddSingleton<IScriptNameCacheRepository, TableScriptNameCacheRepository>();
             return services;

--- a/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigBackupRepository.cs
+++ b/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigBackupRepository.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared;
+using AutopilotMonitor.Shared.DataAccess;
+using AutopilotMonitor.Shared.Models;
+using Azure;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Logging;
+
+namespace AutopilotMonitor.Functions.DataAccess.TableStorage
+{
+    /// <summary>
+    /// Table-storage backend for <see cref="IConfigBackupRepository"/>.
+    /// Fail-loud — callers decide whether a snapshot failure is soft (legacy save hook)
+    /// or hard (transactional patch/revert, which must not write without a backup).
+    /// </summary>
+    public sealed class TableConfigBackupRepository : IConfigBackupRepository
+    {
+        private readonly TableClient _tableClient;
+        private readonly ILogger<TableConfigBackupRepository> _logger;
+
+        public TableConfigBackupRepository(
+            TableStorageService storage,
+            ILogger<TableConfigBackupRepository> logger)
+        {
+            _tableClient = storage.GetTableClient(Constants.TableNames.ConfigurationBackups);
+            _logger = logger;
+        }
+
+        public Task UpsertAsync(ConfigBackupEntry entry, CancellationToken ct = default)
+        {
+            if (entry == null) throw new ArgumentNullException(nameof(entry));
+            if (string.IsNullOrEmpty(entry.PartitionKey)) throw new ArgumentException("PartitionKey required", nameof(entry));
+            if (string.IsNullOrEmpty(entry.RowKey)) throw new ArgumentException("RowKey required", nameof(entry));
+            return _tableClient.UpsertEntityAsync(Store(entry), TableUpdateMode.Replace, ct);
+        }
+
+        public async Task<List<ConfigBackupEntry>> ListByPartitionAsync(
+            string partitionKey, int max = 25, CancellationToken ct = default)
+        {
+            if (max < 1) throw new ArgumentOutOfRangeException(nameof(max));
+
+            var results = new List<ConfigBackupEntry>();
+            var filter = $"PartitionKey eq '{Escape(partitionKey)}'";
+            await foreach (var e in _tableClient.QueryAsync<TableEntity>(filter, cancellationToken: ct))
+            {
+                // Reverse-ticks RowKey → Azure's RowKey-ascending order IS newest-first.
+                results.Add(Map(e));
+                if (results.Count >= max) break;
+            }
+            return results;
+        }
+
+        public async Task<ConfigBackupEntry?> TryGetAsync(
+            string partitionKey, string backupId, CancellationToken ct = default)
+        {
+            try
+            {
+                var response = await _tableClient.GetEntityAsync<TableEntity>(partitionKey, backupId, cancellationToken: ct);
+                return Map(response.Value);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                return null;
+            }
+        }
+
+        public async Task<int> PruneAsync(string partitionKey, int keep, CancellationToken ct = default)
+        {
+            if (keep < 1) throw new ArgumentOutOfRangeException(nameof(keep));
+
+            var filter = $"PartitionKey eq '{Escape(partitionKey)}'";
+            var seen = 0;
+            var deleted = 0;
+            await foreach (var entity in _tableClient.QueryAsync<TableEntity>(
+                filter, select: new[] { "PartitionKey", "RowKey" }, cancellationToken: ct))
+            {
+                seen++;
+                if (seen <= keep) continue;
+
+                try
+                {
+                    await _tableClient.DeleteEntityAsync(entity.PartitionKey, entity.RowKey, ETag.All, ct);
+                    deleted++;
+                }
+                catch (RequestFailedException ex) when (ex.Status == 404)
+                {
+                    // Concurrent prune already removed it — idempotent.
+                }
+            }
+            return deleted;
+        }
+
+        /// <summary>
+        /// Reverse-ticks + short guid: newest sorts first, concurrent writers within the
+        /// same tick cannot collide. The value is the public backupId.
+        /// </summary>
+        public static string BuildRowKey(DateTime utcNow)
+            => $"{DateTime.MaxValue.Ticks - utcNow.Ticks:D19}_{Guid.NewGuid():N}"[..28];
+
+        private static string Escape(string s) => s.Replace("'", "''");
+
+        private static TableEntity Store(ConfigBackupEntry e) => new(e.PartitionKey, e.RowKey)
+        {
+            ["TenantId"] = e.TenantId,
+            ["EntityJson"] = e.EntityJson,
+            ["ChangedBy"] = e.ChangedBy,
+            ["Source"] = e.Source,
+            ["Reason"] = e.Reason,
+            ["DiffJson"] = e.DiffJson,
+            ["BackupTakenAt"] = e.BackupTakenAt,
+        };
+
+        private static ConfigBackupEntry Map(TableEntity e) => new()
+        {
+            PartitionKey = e.PartitionKey,
+            RowKey = e.RowKey,
+            TenantId = e.GetString("TenantId") ?? string.Empty,
+            EntityJson = e.GetString("EntityJson") ?? string.Empty,
+            ChangedBy = e.GetString("ChangedBy") ?? "system",
+            Source = e.GetString("Source") ?? "unknown",
+            Reason = e.GetString("Reason"),
+            DiffJson = e.GetString("DiffJson"),
+            BackupTakenAt = e.GetDateTime("BackupTakenAt") ?? default,
+        };
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
+++ b/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
+using AutopilotMonitor.Functions.Helpers;
 using AutopilotMonitor.Functions.Pagination;
 using AutopilotMonitor.Functions.Services;
 using AutopilotMonitor.Shared;
@@ -25,11 +27,31 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
         private readonly TableClient _adminConfigTableClient;
         private readonly TableClient _previewWhitelistTableClient;
         private readonly TableClient _previewConfigTableClient;
+        private readonly IConfigBackupRepository _backupRepo;
         private readonly ILogger<TableConfigRepository> _logger;
 
-        public TableConfigRepository(TableStorageService storage, ILogger<TableConfigRepository> logger)
+        /// <summary>
+        /// Changes to ONLY these properties do not snapshot the tenant-config row: the
+        /// LastAuthClientId pair flips as an auth-flow side effect and would flood the
+        /// two backup slots with states nobody ever wants to revert to.
+        /// </summary>
+        private static readonly HashSet<string> TenantBackupNoiseProperties = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "LastUpdated", "UpdatedBy", "LastAuthClientId", "LastAuthClientIdSince",
+        };
+
+        private static readonly HashSet<string> AdminBackupNoiseProperties = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "LastUpdated", "UpdatedBy",
+        };
+
+        public TableConfigRepository(
+            TableStorageService storage,
+            IConfigBackupRepository backupRepo,
+            ILogger<TableConfigRepository> logger)
         {
             _logger = logger;
+            _backupRepo = backupRepo;
             _tenantConfigTableClient = storage.GetTableClient(Constants.TableNames.TenantConfiguration);
             _adminConfigTableClient = storage.GetTableClient(Constants.TableNames.AdminConfiguration);
             _previewWhitelistTableClient = storage.GetTableClient(Constants.TableNames.PreviewWhitelist);
@@ -56,8 +78,17 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
             }
         }
 
-        public async Task<bool> SaveTenantConfigurationAsync(TenantConfiguration config)
+        public Task<bool> SaveTenantConfigurationAsync(TenantConfiguration config)
+            => SaveTenantConfigurationAsync(config, backupSource: null, backupReason: null);
+
+        public async Task<bool> SaveTenantConfigurationAsync(
+            TenantConfiguration config, string? backupSource, string? backupReason)
         {
+            await TrySnapshotBeforeSaveAsync(
+                _tenantConfigTableClient, config.TenantId, "config",
+                ConvertFromTenantTableEntity, config, TenantBackupNoiseProperties,
+                config.UpdatedBy, backupSource, backupReason);
+
             try
             {
                 var entity = ConvertToTenantTableEntity(config);
@@ -69,6 +100,91 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
                 _logger.LogError(ex, "Error saving tenant configuration for {TenantId}", config.TenantId);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Pre-write snapshot hook shared by the tenant- and admin-config save paths.
+        /// Fail-SOFT by design: this is a safety net around long-standing writers
+        /// (portal, plan, auth side effects) — a backup-storage hiccup must never turn
+        /// into a config-save outage. The transactional patch/revert flow does its own
+        /// fail-CLOSED snapshot before calling the conditional write and never relies
+        /// on this hook.
+        /// </summary>
+        private async Task TrySnapshotBeforeSaveAsync<TModel>(
+            TableClient tableClient,
+            string partitionKey,
+            string rowKey,
+            Func<TableEntity, TModel> convertFromEntity,
+            TModel incoming,
+            HashSet<string> noiseProperties,
+            string? changedBy,
+            string? source,
+            string? reason) where TModel : class
+        {
+            try
+            {
+                TableEntity existing;
+                try
+                {
+                    existing = (await tableClient.GetEntityAsync<TableEntity>(partitionKey, rowKey)).Value;
+                }
+                catch (RequestFailedException ex) when (ex.Status == 404)
+                {
+                    return; // Row creation — nothing to snapshot.
+                }
+
+                // Compare at MODEL level, not raw-entity level: retrieved entities carry
+                // DateTimeOffset/typing quirks that would false-positive against a freshly
+                // built entity. The model round-trip puts both sides on identical CLR types.
+                var before = convertFromEntity(existing);
+                var changed = ConfigPropertyComparer.GetChangedPropertyNames(before, incoming);
+                changed.ExceptWith(noiseProperties);
+                if (changed.Count == 0)
+                    return; // Noise-only or no-op save — don't burn a backup slot.
+
+                await _backupRepo.UpsertAsync(BuildBackupEntry(
+                    existing, partitionKey, changedBy,
+                    writeSource: source ?? "unknown", reason: reason,
+                    diffJson: JsonSerializer.Serialize(ConfigDiffHelper.GetChanges(before, incoming))));
+
+                await _backupRepo.PruneAsync(partitionKey, Constants.ConfigBackupKeepCount);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Config backup snapshot failed for {PartitionKey} — proceeding with save (fail-soft)",
+                    partitionKey);
+            }
+        }
+
+        /// <summary>
+        /// Snapshots the raw stored row (same fidelity approach as the offboarding
+        /// customs archive): every table property except the Azure pseudo-properties,
+        /// serialized as JSON. Restore therefore survives model refactors.
+        /// </summary>
+        internal static ConfigBackupEntry BuildBackupEntry(
+            TableEntity sourceRow, string partitionKey, string? changedBy,
+            string writeSource, string? reason, string? diffJson)
+        {
+            var snapshot = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var kv in sourceRow)
+            {
+                if (kv.Key is "odata.etag" or "Timestamp") continue;
+                snapshot[kv.Key] = kv.Value;
+            }
+
+            return new ConfigBackupEntry
+            {
+                PartitionKey = partitionKey,
+                RowKey = TableConfigBackupRepository.BuildRowKey(DateTime.UtcNow),
+                TenantId = partitionKey,
+                EntityJson = JsonSerializer.Serialize(snapshot),
+                ChangedBy = string.IsNullOrWhiteSpace(changedBy) ? "system" : changedBy,
+                Source = writeSource,
+                Reason = reason,
+                DiffJson = diffJson,
+                BackupTakenAt = DateTime.UtcNow,
+            };
         }
 
         /// <summary>
@@ -181,6 +297,11 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
 
         public async Task<bool> SaveAdminConfigurationAsync(AdminConfiguration config)
         {
+            await TrySnapshotBeforeSaveAsync(
+                _adminConfigTableClient, "GlobalConfig", "config",
+                ConvertFromAdminTableEntity, config, AdminBackupNoiseProperties,
+                config.UpdatedBy, "admin-config", reason: null);
+
             try
             {
                 var entity = ConvertToAdminTableEntity(config);
@@ -640,7 +761,7 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
 
         // --- Admin Configuration Entity Mapping ---
 
-        private TableEntity ConvertToAdminTableEntity(AdminConfiguration config)
+        internal static TableEntity ConvertToAdminTableEntity(AdminConfiguration config)
         {
             var entity = new TableEntity("GlobalConfig", "config")
             {
@@ -705,7 +826,7 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
             return entity;
         }
 
-        private AdminConfiguration ConvertFromAdminTableEntity(TableEntity entity)
+        internal static AdminConfiguration ConvertFromAdminTableEntity(TableEntity entity)
         {
             return new AdminConfiguration
             {

--- a/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
+++ b/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
@@ -102,6 +102,38 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
             }
         }
 
+        public async Task<(TenantConfiguration Config, string ETag)?> GetTenantConfigurationWithEtagAsync(string tenantId)
+        {
+            try
+            {
+                var entity = await _tenantConfigTableClient.GetEntityAsync<TableEntity>(tenantId, "config");
+                return (ConvertFromTenantTableEntity(entity.Value), entity.Value.ETag.ToString());
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                return null;
+            }
+            // Everything else throws (fail-loud): the transactional caller must never treat a
+            // storage outage as "no row".
+        }
+
+        public async Task<bool> TryReplaceTenantConfigurationAsync(TenantConfiguration config, string etag)
+        {
+            var entity = ConvertToTenantTableEntity(config);
+            try
+            {
+                await _tenantConfigTableClient.UpdateEntityAsync(entity, new ETag(etag), TableUpdateMode.Replace);
+                return true;
+            }
+            catch (RequestFailedException ex) when (ex.Status is 412 or 404)
+            {
+                // 412: lost the CAS race — caller re-reads and retries (bounded).
+                // 404: the row was deleted since the read (offboarding) — the retry's
+                //      re-read surfaces that as "no configuration row".
+                return false;
+            }
+        }
+
         /// <summary>
         /// Pre-write snapshot hook shared by the tenant- and admin-config save paths.
         /// Fail-SOFT by design: this is a safety net around long-standing writers

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Admin/TenantOffboardFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Admin/TenantOffboardFunction.cs
@@ -614,7 +614,7 @@ public class TenantOffboardFunction
         var writtenAt = DateTime.UtcNow;
         tenantConfig.LastUpdated = writtenAt;
 
-        var saved = await _configRepo.SaveTenantConfigurationAsync(tenantConfig);
+        var saved = await _configRepo.SaveTenantConfigurationAsync(tenantConfig, "offboard", "Disabled-gate before cascade");
         if (!saved)
         {
             // TableConfigRepository.SaveTenantConfigurationAsync returns false on transient

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/GetTenantConfigurationFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/GetTenantConfigurationFunction.cs
@@ -49,7 +49,7 @@ namespace AutopilotMonitor.Functions.Functions.Config
                 // even when they happen to be an admin of their own home tenant. This also prevents a
                 // "***REDACTED***" placeholder from ever reaching the Settings save round-trip for an
                 // own-tenant admin.
-                if (!CanViewSecrets(requestCtx))
+                if (ShouldRedact(requestCtx, req.Url.Query))
                     config = config.RedactedCopyForReader();
 
                 var response = req.CreateResponse(HttpStatusCode.OK);
@@ -80,6 +80,20 @@ namespace AutopilotMonitor.Functions.Functions.Config
             var ownTenantAdminView = ctx.IsTenantAdmin
                 && string.Equals(ctx.TargetTenantId, ctx.TenantId, StringComparison.OrdinalIgnoreCase);
             return ctx.IsGlobalAdmin || ownTenantAdminView;
+        }
+
+        /// <summary>
+        /// Redaction decision including the ?view=redacted opt-in, which forces the redacted
+        /// copy even for callers WITH secret clearance. Exists for the MCP get_tenant_config
+        /// tool: a Global Admin's MCP session must never pull clear-text webhook/SAS secrets
+        /// into model context. Pure static for unit-testing without an HttpRequestData mock.
+        /// </summary>
+        internal static bool ShouldRedact(RequestContext ctx, string query)
+        {
+            var forceRedacted = string.Equals(
+                System.Web.HttpUtility.ParseQueryString(query)["view"],
+                "redacted", StringComparison.OrdinalIgnoreCase);
+            return forceRedacted || !CanViewSecrets(ctx);
         }
     }
 }

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/ListTenantConfigBackupsFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/ListTenantConfigBackupsFunction.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.Helpers;
+using AutopilotMonitor.Shared.DataAccess;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace AutopilotMonitor.Functions.Functions.Config
+{
+    /// <summary>
+    /// Lists a tenant's pre-write config snapshots — METADATA ONLY. The stored EntityJson
+    /// holds the raw row including clear-text secrets (webhook URLs, SAS) and is NEVER
+    /// returned here: responses reach model context via MCP. The masked DiffJson is the
+    /// only change summary exposed.
+    /// </summary>
+    public class ListTenantConfigBackupsFunction
+    {
+        private const int MaxListSize = 25;
+
+        private readonly ILogger<ListTenantConfigBackupsFunction> _logger;
+        private readonly IConfigBackupRepository _backupRepo;
+
+        public ListTenantConfigBackupsFunction(
+            ILogger<ListTenantConfigBackupsFunction> logger,
+            IConfigBackupRepository backupRepo)
+        {
+            _logger = logger;
+            _backupRepo = backupRepo;
+        }
+
+        [Function("ListTenantConfigBackups")]
+        public async Task<HttpResponseData> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "config/{tenantId}/backups")] HttpRequestData req,
+            string tenantId)
+        {
+            try
+            {
+                // Authentication + GlobalAdminOnly authorization enforced by PolicyEnforcementMiddleware.
+                var requestCtx = req.GetRequestContext();
+
+                var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+                var max = int.TryParse(query["max"], out var parsed)
+                    ? Math.Clamp(parsed, 1, MaxListSize)
+                    : MaxListSize;
+
+                var backups = await _backupRepo.ListByPartitionAsync(requestCtx.TargetTenantId, max);
+
+                var response = req.CreateResponse(HttpStatusCode.OK);
+                await response.WriteAsJsonAsync(new
+                {
+                    tenantId = requestCtx.TargetTenantId,
+                    backups = backups.Select(b => new
+                    {
+                        backupId = b.RowKey,
+                        backupTakenAt = b.BackupTakenAt,
+                        changedBy = b.ChangedBy,
+                        source = b.Source,
+                        reason = b.Reason,
+                        diff = TryParseDiff(b.DiffJson),
+                    }),
+                });
+                return response;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error listing config backups for tenant {TenantId}", tenantId);
+                var response = req.CreateResponse(HttpStatusCode.InternalServerError);
+                await response.WriteAsJsonAsync(new { error = "Internal server error" });
+                return response;
+            }
+        }
+
+        private static Dictionary<string, string>? TryParseDiff(string? diffJson)
+        {
+            if (string.IsNullOrWhiteSpace(diffJson)) return null;
+            try
+            {
+                return System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(diffJson);
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return null; // advisory only — a malformed stored diff must not break the listing
+            }
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/PatchTenantConfigurationFieldsFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/PatchTenantConfigurationFieldsFunction.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.Helpers;
+using AutopilotMonitor.Functions.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AutopilotMonitor.Functions.Functions.Config
+{
+    /// <summary>
+    /// Transactional field-level patch of a tenant's configuration (GlobalAdminOnly for now;
+    /// phase 2 widens the policy line + caller tier). Unlike the full-model PUT, this takes
+    /// ONLY the fields to change, and the service verifies after the conditional write that
+    /// exactly those fields changed — rolling back automatically on drift. Every write is
+    /// preceded by a fail-closed snapshot into ConfigurationBackups (revertible via
+    /// POST config/{tenantId}/revert).
+    /// </summary>
+    public class PatchTenantConfigurationFieldsFunction
+    {
+        internal const int MaxBodyBytes = 65_536;
+
+        private readonly ILogger<PatchTenantConfigurationFieldsFunction> _logger;
+        private readonly TenantConfigPatchService _patchService;
+
+        public PatchTenantConfigurationFieldsFunction(
+            ILogger<PatchTenantConfigurationFieldsFunction> logger,
+            TenantConfigPatchService patchService)
+        {
+            _logger = logger;
+            _patchService = patchService;
+        }
+
+        public sealed class PatchFieldsRequest
+        {
+            public JObject? Fields { get; set; }
+            public string? Reason { get; set; }
+        }
+
+        [Function("PatchTenantConfigurationFields")]
+        public async Task<HttpResponseData> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "config/{tenantId}/fields")] HttpRequestData req,
+            string tenantId)
+        {
+            try
+            {
+                // Authentication + GlobalAdminOnly authorization enforced by PolicyEnforcementMiddleware.
+                var requestCtx = req.GetRequestContext();
+
+                if (req.Headers.TryGetValues("Content-Length", out var clValues)
+                    && long.TryParse(clValues.FirstOrDefault(), out var contentLength)
+                    && contentLength > MaxBodyBytes)
+                {
+                    return await WriteError(req, HttpStatusCode.BadRequest, "Request body too large");
+                }
+
+                var body = await new StreamReader(req.Body).ReadToEndAsync();
+                PatchFieldsRequest? request;
+                try
+                {
+                    request = JsonConvert.DeserializeObject<PatchFieldsRequest>(body);
+                }
+                catch (JsonException)
+                {
+                    return await WriteError(req, HttpStatusCode.BadRequest, "Invalid JSON body");
+                }
+                if (request?.Fields == null || !request.Fields.Properties().Any())
+                {
+                    return await WriteError(req, HttpStatusCode.BadRequest,
+                        "Body must be { \"fields\": { <fieldName>: <value>, ... }, \"reason\": \"...\" } with at least one field.");
+                }
+
+                _logger.LogInformation(
+                    "PatchTenantConfigurationFields: {TenantId} by {User} ({FieldCount} fields)",
+                    requestCtx.TargetTenantId, requestCtx.UserPrincipalName, request.Fields.Count);
+
+                var outcome = await _patchService.ApplyFieldPatchAsync(
+                    requestCtx.TargetTenantId,
+                    request.Fields,
+                    requestCtx.UserPrincipalName,
+                    ResolveSource(req, "patch"),
+                    request.Reason,
+                    TenantConfigCallerTier.GlobalAdmin);
+
+                return await WriteOutcome(req, outcome);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error patching configuration for tenant {TenantId}", tenantId);
+                var response = req.CreateResponse(HttpStatusCode.InternalServerError);
+                await response.WriteAsJsonAsync(new { error = "Internal server error" });
+                return response;
+            }
+        }
+
+        /// <summary>Tags the backup Source with the write path (MCP tools stamp X-Client-Source: mcp).</summary>
+        internal static string ResolveSource(HttpRequestData req, string operation)
+            => req.Headers.TryGetValues("X-Client-Source", out var values)
+               && string.Equals(values.FirstOrDefault(), "mcp", StringComparison.OrdinalIgnoreCase)
+                ? $"mcp-{operation}"
+                : $"api-{operation}";
+
+        internal static async Task<HttpResponseData> WriteOutcome(HttpRequestData req, PatchOutcome outcome)
+        {
+            if (outcome.Success)
+            {
+                var ok = req.CreateResponse(HttpStatusCode.OK);
+                await ok.WriteAsJsonAsync(new
+                {
+                    success = true,
+                    appliedFields = outcome.AppliedFields,
+                    diff = outcome.MaskedDiff,
+                    backupId = outcome.BackupId,
+                    noOp = outcome.AppliedFields.Count == 0,
+                });
+                return ok;
+            }
+
+            var status = outcome.Failure switch
+            {
+                PatchFailure.NotFound => HttpStatusCode.NotFound,
+                PatchFailure.InvalidField => HttpStatusCode.BadRequest,
+                PatchFailure.ValidationFailed => HttpStatusCode.BadRequest,
+                PatchFailure.BackupFailed => HttpStatusCode.ServiceUnavailable,
+                PatchFailure.WriteConflict => HttpStatusCode.Conflict,
+                // Drift means the write was undone (or needs manual attention) — surface as 500:
+                // the caller changed nothing durable and must involve an operator.
+                _ => HttpStatusCode.InternalServerError,
+            };
+            var error = req.CreateResponse(status);
+            await error.WriteAsJsonAsync(new
+            {
+                success = false,
+                message = outcome.Error,
+                backupId = outcome.BackupId,
+                drift = outcome.Drift,
+            });
+            return error;
+        }
+
+        private static async Task<HttpResponseData> WriteError(HttpRequestData req, HttpStatusCode status, string message)
+        {
+            var response = req.CreateResponse(status);
+            await response.WriteAsJsonAsync(new { success = false, message });
+            return response;
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/PlanManagementFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/PlanManagementFunction.cs
@@ -162,7 +162,7 @@ namespace AutopilotMonitor.Functions.Functions.Config
                     // Fail-loud: SaveConfigurationAsync throws when the write did not persist (and
                     // invalidates the cached — possibly mutated — instance in its finally), so a
                     // failed save can never be audited or returned as 200.
-                    await _configService.SaveConfigurationAsync(config);
+                    await _configService.SaveConfigurationAsync(config, "plan", "plan tier change");
 
                     await _maintenanceRepo.LogAuditEntryAsync(
                         requestCtx.TargetTenantId,
@@ -265,7 +265,7 @@ namespace AutopilotMonitor.Functions.Functions.Config
                 config.UpdatedBy = caller;
 
                 // Fail-loud: throws when the write did not persist (cache invalidated in finally).
-                await _configService.SaveConfigurationAsync(config);
+                await _configService.SaveConfigurationAsync(config, "plan", "self-service trial start");
 
                 await _maintenanceRepo.LogAuditEntryAsync(
                     requestCtx.TargetTenantId,

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/RevertTenantConfigurationFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/RevertTenantConfigurationFunction.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.Helpers;
+using AutopilotMonitor.Functions.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace AutopilotMonitor.Functions.Functions.Config
+{
+    /// <summary>
+    /// Restores a tenant's configuration from a ConfigurationBackups snapshot (latest by
+    /// default). The revert itself snapshots the current state first — so a revert is
+    /// always revertible — and runs through the same CAS-write + exactly-these-fields
+    /// verification as the field patch. Protected/system-owned fields (plan/trial,
+    /// HomedAppClientId, auth provenance) stay at their CURRENT values unless
+    /// includeProtectedFields is explicitly set.
+    /// </summary>
+    public class RevertTenantConfigurationFunction
+    {
+        private readonly ILogger<RevertTenantConfigurationFunction> _logger;
+        private readonly TenantConfigPatchService _patchService;
+
+        public RevertTenantConfigurationFunction(
+            ILogger<RevertTenantConfigurationFunction> logger,
+            TenantConfigPatchService patchService)
+        {
+            _logger = logger;
+            _patchService = patchService;
+        }
+
+        public sealed class RevertRequest
+        {
+            public string? BackupId { get; set; }
+            public bool IncludeProtectedFields { get; set; }
+            public string? Reason { get; set; }
+        }
+
+        [Function("RevertTenantConfiguration")]
+        public async Task<HttpResponseData> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "config/{tenantId}/revert")] HttpRequestData req,
+            string tenantId)
+        {
+            try
+            {
+                // Authentication + GlobalAdminOnly authorization enforced by PolicyEnforcementMiddleware.
+                var requestCtx = req.GetRequestContext();
+
+                RevertRequest? request;
+                try
+                {
+                    var body = await new StreamReader(req.Body).ReadToEndAsync();
+                    request = string.IsNullOrWhiteSpace(body)
+                        ? new RevertRequest()
+                        : JsonConvert.DeserializeObject<RevertRequest>(body);
+                }
+                catch (JsonException)
+                {
+                    var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
+                    await badRequest.WriteAsJsonAsync(new { success = false, message = "Invalid JSON body" });
+                    return badRequest;
+                }
+                request ??= new RevertRequest();
+
+                _logger.LogWarning(
+                    "RevertTenantConfiguration: {TenantId} by {User} (backupId={BackupId}, includeProtectedFields={IncludeProtected})",
+                    requestCtx.TargetTenantId, requestCtx.UserPrincipalName,
+                    request.BackupId ?? "(latest)", request.IncludeProtectedFields);
+
+                var outcome = await _patchService.RevertAsync(
+                    requestCtx.TargetTenantId,
+                    request.BackupId,
+                    request.IncludeProtectedFields,
+                    requestCtx.UserPrincipalName,
+                    PatchTenantConfigurationFieldsFunction.ResolveSource(req, "revert"),
+                    request.Reason,
+                    TenantConfigCallerTier.GlobalAdmin);
+
+                return await PatchTenantConfigurationFieldsFunction.WriteOutcome(req, outcome);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reverting configuration for tenant {TenantId}", tenantId);
+                var response = req.CreateResponse(HttpStatusCode.InternalServerError);
+                await response.WriteAsJsonAsync(new { error = "Internal server error" });
+                return response;
+            }
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/UpdateTenantConfigurationFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/UpdateTenantConfigurationFunction.cs
@@ -250,7 +250,7 @@ namespace AutopilotMonitor.Functions.Functions.Config
                 }
 
                 // Save configuration
-                await _configService.SaveConfigurationAsync(config);
+                await _configService.SaveConfigurationAsync(config, "portal-put", null);
 
                 var changes = ConfigDiffHelper.GetChanges(existingConfig, config);
                 await _maintenanceRepo.LogAuditEntryAsync(

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/UpdateTenantConfigurationFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/UpdateTenantConfigurationFunction.cs
@@ -63,28 +63,6 @@ namespace AutopilotMonitor.Functions.Functions.Config
                     return badRequest;
                 }
 
-                // Per-tenant rate-limit overrides are optional (null = inherit global), but if provided
-                // they must be positive — a zero/negative override would throttle every request.
-                var customLimitError =
-                    config.CustomRateLimitRequestsPerMinute is int dev && dev < 1 ? "Device API Rate Limit" :
-                    config.CustomUserRateLimitRequestsPerMinute is int usr && usr < 1 ? "User API Rate Limit" :
-                    null;
-                if (customLimitError != null)
-                {
-                    var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new { success = false, message = $"{customLimitError} override must be at least 1 request per minute (or left blank to inherit the global default)." });
-                    return badRequest;
-                }
-
-                // The contact address is where enforcement actions and service notices are sent,
-                // so it must be an address rather than whatever string a direct API caller posts.
-                var contactEmailError = ValidateContactEmail(config.ContactEmail);
-                if (contactEmailError != null)
-                {
-                    var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new { success = false, message = $"Invalid contact email: {contactEmailError}" });
-                    return badRequest;
-                }
                 // Normalize so the stored value never carries surrounding whitespace, and an
                 // all-whitespace submission clears the field instead of masquerading as a value.
                 config.ContactEmail = string.IsNullOrWhiteSpace(config.ContactEmail) ? null : config.ContactEmail.Trim();
@@ -99,53 +77,15 @@ namespace AutopilotMonitor.Functions.Functions.Config
                 // admins are served the FULL config so this is normally a no-op for them.)
                 config.RestoreRedactedSecretsFrom(existingConfig);
 
-                // Validate webhook URLs (SSRF protection)
-                var webhookUrlError = SsrfGuard.ValidateWebhookUrlFormat(config.WebhookUrl);
-                if (webhookUrlError != null)
+                // Shared model validation (rate limits, contact address, webhook/Teams SSRF, custom
+                // headers, notification channels, diagnostics SAS, retention cap) — single source
+                // with the transactional field-patch flow (TenantConfigValidation).
+                var validationError = TenantConfigValidation.ValidateModel(config, existingConfig, requestCtx.IsGlobalAdmin);
+                if (validationError != null)
                 {
                     var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new { success = false, message = $"Invalid Webhook URL: {webhookUrlError}" });
+                    await badRequest.WriteAsJsonAsync(new { success = false, message = validationError });
                     return badRequest;
-                }
-                var teamsUrlError = SsrfGuard.ValidateWebhookUrlFormat(config.TeamsWebhookUrl);
-                if (teamsUrlError != null)
-                {
-                    var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new { success = false, message = $"Invalid Teams Webhook URL: {teamsUrlError}" });
-                    return badRequest;
-                }
-                var headersError = ValidateWebhookCustomHeaders(config.WebhookCustomHeadersJson);
-                if (headersError != null)
-                {
-                    var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new { success = false, message = $"Invalid custom headers: {headersError}" });
-                    return badRequest;
-                }
-                // Per-channel counterpart of the two checks above: every channel's URL and custom
-                // headers must pass the same format/SSRF gates as the legacy single-webhook fields.
-                var channelsError = ValidateNotificationChannels(config.NotificationChannelsJson);
-                if (channelsError != null)
-                {
-                    var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new { success = false, message = $"Invalid notification channels: {channelsError}" });
-                    return badRequest;
-                }
-                // Only validate the customer-supplied SAS URL when the tenant has actually
-                // selected the CustomerSas destination. In Hosted mode the field is unused at
-                // runtime (see GetDiagnosticsUploadUrlFunction), so a stale/legacy value left
-                // over from a prior CustomerSas configuration must not block a Hosted save.
-                // Mirrors the runtime branching in GetDiagnosticsUploadUrlFunction.Run.
-                var diagDestination = AutopilotMonitor.Functions.Functions.Diagnostics.GetDiagnosticsUploadUrlFunction
-                    .NormalizeDestination(config.DiagnosticsUploadDestination);
-                if (diagDestination == AutopilotMonitor.Functions.Functions.Diagnostics.GetDiagnosticsUploadUrlFunction.DestinationCustomerSas)
-                {
-                    var diagSasError = SsrfGuard.ValidateAzureBlobSasUrlFormat(config.DiagnosticsBlobSasUrl);
-                    if (diagSasError != null)
-                    {
-                        var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                        await badRequest.WriteAsJsonAsync(new { success = false, message = $"Invalid Diagnostics SAS URL: {diagSasError}" });
-                        return badRequest;
-                    }
                 }
 
                 // Ensure tenant ID matches
@@ -227,29 +167,7 @@ namespace AutopilotMonitor.Functions.Functions.Config
                 config.TrialConsumed = existingConfig.TrialConsumed;
                 config.TrialGrantedBy = existingConfig.TrialGrantedBy;
 
-                // Retention cap (edition entitlement): non-GA callers may only set 7..cap days.
-                // Enforced only when the caller actually CHANGED the value, so a tenant whose
-                // stored value predates the cap (e.g. 180 on Community) can still save unrelated
-                // settings. 0 (= infinite) is a GA-only escape hatch. Edition resolves from the
-                // STORED config — the client-sent plan fields were just discarded above.
-                if (!requestCtx.IsGlobalAdmin && config.DataRetentionDays != existingConfig.DataRetentionDays)
-                {
-                    var cap = FeatureEntitlementCatalog
-                        .Get(TenantEntitlementService.ResolveEdition(existingConfig, DateTime.UtcNow))
-                        .RetentionCapDays;
-                    if (config.DataRetentionDays < 7 || config.DataRetentionDays > cap)
-                    {
-                        var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                        await badRequest.WriteAsJsonAsync(new
-                        {
-                            success = false,
-                            message = $"Data retention must be between 7 and {cap} days for your plan. Upgrade to Pro for up to 365 days."
-                        });
-                        return badRequest;
-                    }
-                }
-
-                // Save configuration
+                // Save configuration (retention cap already enforced by ValidateModel above)
                 await _configService.SaveConfigurationAsync(config, "portal-put", null);
 
                 var changes = ConfigDiffHelper.GetChanges(existingConfig, config);
@@ -280,180 +198,18 @@ namespace AutopilotMonitor.Functions.Functions.Config
             }
         }
 
-        private const int MaxCustomHeadersJsonLength = 8192;
-        private const int MaxCustomHeaderCount = 25;
-        private const int MaxNotificationChannelsJsonLength = 65536;
+        // Forwarding shims — the implementations moved to TenantConfigValidation (shared with
+        // the transactional field-patch flow). Kept so existing callers and the validator test
+        // suites keep their call sites; new code should reference TenantConfigValidation.
+        internal const int MaxContactEmailLength = TenantConfigValidation.MaxContactEmailLength;
 
-        // RFC 5321 caps a forward path at 254 characters.
-        internal const int MaxContactEmailLength = 254;
-
-        /// <summary>
-        /// Validates the tenant contact address. Returns an error message, or null when valid/empty.
-        /// Empty is legitimate — it means we have no way to reach the tenant.
-        /// <para>
-        /// Deliberately not an RFC 5322 parser: the job is to reject values that are not addresses
-        /// at all. Specifically it rejects recipient lists (a comma would silently widen who receives
-        /// service notices), display-name forms, and control characters (which would let a caller
-        /// forge mail headers once this address is actually mailed).
-        /// </para>
-        /// </summary>
         internal static string? ValidateContactEmail(string? email)
-        {
-            if (string.IsNullOrWhiteSpace(email))
-                return null;
+            => TenantConfigValidation.ValidateContactEmail(email);
 
-            var trimmed = email.Trim();
-
-            if (trimmed.Length > MaxContactEmailLength)
-                return $"must be at most {MaxContactEmailLength} characters.";
-
-            foreach (var ch in trimmed)
-            {
-                if (char.IsControl(ch))
-                    return "must not contain control characters.";
-                if (char.IsWhiteSpace(ch) || ch == ',' || ch == ';' || ch == '<' || ch == '>')
-                    return "must be a single address, without spaces, separators or angle brackets.";
-            }
-
-            var at = trimmed.IndexOf('@');
-            if (at <= 0 || at != trimmed.LastIndexOf('@') || at == trimmed.Length - 1)
-                return "must contain a single \"@\" with text on both sides.";
-
-            // A bare host with no dot is unreachable from our sender, so it is a typo, not an address.
-            var domain = trimmed.Substring(at + 1);
-            if (!domain.Contains('.') || domain.StartsWith(".", StringComparison.Ordinal)
-                || domain.EndsWith(".", StringComparison.Ordinal))
-            {
-                return "the domain part must be a dotted host name.";
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Validates the notification-channel list JSON. Returns an error message, or null when
-        /// valid/empty. Strict counterpart of the fail-soft <c>NotificationChannel.ParseList</c>:
-        /// entries the parser would silently drop (missing id, unknown provider) are rejected here
-        /// so a tenant admin gets feedback instead of a channel that never fires. Each channel's
-        /// URL and custom headers pass the same gates as the legacy single-webhook fields.
-        /// </summary>
         internal static string? ValidateNotificationChannels(string? json)
-        {
-            if (string.IsNullOrWhiteSpace(json))
-                return null;
+            => TenantConfigValidation.ValidateNotificationChannels(json);
 
-            if (json.Length > MaxNotificationChannelsJsonLength)
-                return $"too large (max {MaxNotificationChannelsJsonLength} characters).";
-
-            List<Shared.Models.Notifications.NotificationChannel>? channels;
-            try
-            {
-                channels = System.Text.Json.JsonSerializer.Deserialize<List<Shared.Models.Notifications.NotificationChannel>>(
-                    json, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            }
-            catch (System.Text.Json.JsonException)
-            {
-                return "not valid JSON.";
-            }
-
-            if (channels == null)
-                return "must be a JSON array of channels.";
-
-            if (channels.Count > Shared.Models.Notifications.NotificationChannel.MaxChannelsPerTenant)
-                return $"too many channels (max {Shared.Models.Notifications.NotificationChannel.MaxChannelsPerTenant}).";
-
-            var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var channel in channels)
-            {
-                if (channel == null || string.IsNullOrWhiteSpace(channel.Id))
-                    return "every channel needs an id.";
-                if (!ids.Add(channel.Id))
-                    return $"duplicate channel id \"{channel.Id}\".";
-
-                var label = string.IsNullOrWhiteSpace(channel.Name) ? channel.Id : channel.Name;
-
-                if (!Enum.IsDefined(typeof(Shared.Models.Notifications.WebhookProviderType), channel.ProviderType)
-                    || channel.ProviderType == (int)Shared.Models.Notifications.WebhookProviderType.None)
-                    return $"channel \"{label}\" has an invalid provider type.";
-
-                var urlError = SsrfGuard.ValidateWebhookUrlFormat(channel.Url);
-                if (urlError != null)
-                    return $"channel \"{label}\": {urlError}";
-
-                var headerError = ValidateWebhookCustomHeaders(channel.CustomHeadersJson);
-                if (headerError != null)
-                    return $"channel \"{label}\" headers: {headerError}";
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Validates the generic-webhook custom-headers JSON. Returns an error message, or null when
-        /// valid/empty. Enforces a JSON object of string values, valid HTTP token names, no CR/LF
-        /// header-injection, and size caps. Restricted (framing/host/content) headers are not rejected
-        /// here — they are silently ignored at dispatch by TenantConfiguration.GetGenericWebhookHeaders().
-        /// </summary>
         internal static string? ValidateWebhookCustomHeaders(string? json)
-        {
-            if (string.IsNullOrWhiteSpace(json))
-                return null;
-
-            if (json.Length > MaxCustomHeadersJsonLength)
-                return $"too large (max {MaxCustomHeadersJsonLength} characters).";
-
-            System.Text.Json.JsonDocument doc;
-            try
-            {
-                doc = System.Text.Json.JsonDocument.Parse(json);
-            }
-            catch (System.Text.Json.JsonException)
-            {
-                return "not valid JSON.";
-            }
-
-            using (doc)
-            {
-                if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
-                    return "must be a JSON object of header name/value pairs.";
-
-                var count = 0;
-                foreach (var prop in doc.RootElement.EnumerateObject())
-                {
-                    if (++count > MaxCustomHeaderCount)
-                        return $"too many headers (max {MaxCustomHeaderCount}).";
-
-                    if (prop.Value.ValueKind != System.Text.Json.JsonValueKind.String)
-                        return $"header \"{prop.Name}\" must have a string value.";
-
-                    if (!IsValidHeaderName(prop.Name))
-                        return $"\"{prop.Name}\" is not a valid HTTP header name.";
-
-                    var value = prop.Value.GetString();
-                    if (value != null && (value.IndexOf('\r') >= 0 || value.IndexOf('\n') >= 0))
-                        return $"value for \"{prop.Name}\" must not contain line breaks.";
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>Validates an HTTP header name as an RFC 7230 token (no whitespace, controls, or separators).</summary>
-        private static bool IsValidHeaderName(string name)
-        {
-            if (string.IsNullOrEmpty(name))
-                return false;
-
-            foreach (var ch in name)
-            {
-                var isTokenChar =
-                    (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') ||
-                    "!#$%&'*+-.^_`|~".IndexOf(ch) >= 0;
-                if (!isTokenChar)
-                    return false;
-            }
-
-            return true;
-        }
+            => TenantConfigValidation.ValidateWebhookCustomHeaders(json);
     }
 }

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Infrastructure/AuthFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Infrastructure/AuthFunction.cs
@@ -327,7 +327,7 @@ public class AuthFunction
         }
         try
         {
-            await _tenantConfigService.SaveConfigurationAsync(tenantConfig);
+            await _tenantConfigService.SaveConfigurationAsync(tenantConfig, "auth", "first-login domain seed");
         }
         catch (Exception ex)
         {
@@ -401,7 +401,7 @@ public class AuthFunction
                 return;
             fresh.LastAuthClientId = clientId;
             fresh.LastAuthClientIdSince = DateTime.UtcNow;
-            await _tenantConfigService.SaveConfigurationAsync(fresh);
+            await _tenantConfigService.SaveConfigurationAsync(fresh, "auth", "auth client-id tracking");
         }
         catch (Exception ex)
         {
@@ -431,7 +431,7 @@ public class AuthFunction
         tenantConfig.UpdatedBy = "System (auto-re-enable)";
         try
         {
-            await _tenantConfigService.SaveConfigurationAsync(tenantConfig);
+            await _tenantConfigService.SaveConfigurationAsync(tenantConfig, "auth", "auto-re-enable after suspension expiry");
         }
         catch (Exception ex)
         {

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Maintenance/OffboardingMarkerCleanupFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Maintenance/OffboardingMarkerCleanupFunction.cs
@@ -162,6 +162,13 @@ namespace AutopilotMonitor.Functions.Functions.Maintenance
                                     "OffboardingMarkerCleanup: swept lingering TenantConfiguration tombstone for tenant={Tenant} (Phase 2.F-final must have failed in the handler)",
                                     marker.TenantId);
                             }
+
+                            // A save against the lingering tombstone (auth side effects) may have
+                            // re-created config backup snapshots AFTER the cascade's bulk wipe.
+                            // Sweep them under the same tombstone condition — a re-onboarded
+                            // tenant (else-branch) keeps its fresh backups untouched.
+                            await _safeWipe.WipeByExactPartitionAsync(
+                                Constants.TableNames.ConfigurationBackups, marker.TenantId, ct);
                         }
                         else
                         {

--- a/src/Backend/AutopilotMonitor.Functions/Helpers/ConfigPropertyComparer.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Helpers/ConfigPropertyComparer.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace AutopilotMonitor.Functions.Helpers
+{
+    /// <summary>
+    /// Precise, unmasked property-level comparison of two config objects. Returns the NAMES
+    /// of every changed property (values never leave this method), excluding only the table
+    /// plumbing keys — unlike <see cref="ConfigDiffHelper"/>, LastUpdated/UpdatedBy/TenantId
+    /// ARE visible, because callers (backup noise filter, transactional write verification)
+    /// must see every real difference.
+    /// </summary>
+    public static class ConfigPropertyComparer
+    {
+        private static readonly HashSet<string> ExcludedProperties = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "PartitionKey", "RowKey", "Timestamp", "ETag",
+        };
+
+        public static HashSet<string> GetChangedPropertyNames<T>(T a, T b) where T : class
+        {
+            var changed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (a == null || b == null) throw new ArgumentNullException(a == null ? nameof(a) : nameof(b));
+
+            foreach (var prop in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!prop.CanRead) continue;
+                if (prop.GetIndexParameters().Length > 0) continue;
+                if (ExcludedProperties.Contains(prop.Name)) continue;
+
+                if (!Equals(prop.GetValue(a), prop.GetValue(b)))
+                    changed.Add(prop.Name);
+            }
+
+            return changed;
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Helpers/TenantConfigValidation.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Helpers/TenantConfigValidation.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using AutopilotMonitor.Functions.Security;
+using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Functions.Helpers
+{
+    /// <summary>
+    /// Single source for tenant-configuration model validation, shared by the full-model
+    /// PUT (<c>UpdateTenantConfigurationFunction</c>) and the transactional field-patch
+    /// flow (<c>TenantConfigPatchService</c>). The individual validators moved here from
+    /// the PUT function; thin forwarding shims remain there for existing callers/tests.
+    /// </summary>
+    internal static class TenantConfigValidation
+    {
+        private const int MaxCustomHeadersJsonLength = 8192;
+        private const int MaxCustomHeaderCount = 25;
+        private const int MaxNotificationChannelsJsonLength = 65536;
+
+        // RFC 5321 caps a forward path at 254 characters.
+        internal const int MaxContactEmailLength = 254;
+
+        /// <summary>
+        /// Validates a candidate configuration against the stored one. Returns a
+        /// user-facing error message (same wording the PUT endpoint always produced),
+        /// or null when the candidate is saveable. Does NOT mutate either argument.
+        /// </summary>
+        internal static string? ValidateModel(
+            TenantConfiguration candidate, TenantConfiguration existing, bool isGlobalAdmin)
+        {
+            // Per-tenant rate-limit overrides are optional (null = inherit global), but if provided
+            // they must be positive — a zero/negative override would throttle every request.
+            var customLimitError =
+                candidate.CustomRateLimitRequestsPerMinute is int dev && dev < 1 ? "Device API Rate Limit" :
+                candidate.CustomUserRateLimitRequestsPerMinute is int usr && usr < 1 ? "User API Rate Limit" :
+                null;
+            if (customLimitError != null)
+                return $"{customLimitError} override must be at least 1 request per minute (or left blank to inherit the global default).";
+
+            var contactEmailError = ValidateContactEmail(candidate.ContactEmail);
+            if (contactEmailError != null)
+                return $"Invalid contact email: {contactEmailError}";
+
+            var webhookUrlError = SsrfGuard.ValidateWebhookUrlFormat(candidate.WebhookUrl);
+            if (webhookUrlError != null)
+                return $"Invalid Webhook URL: {webhookUrlError}";
+
+            var teamsUrlError = SsrfGuard.ValidateWebhookUrlFormat(candidate.TeamsWebhookUrl);
+            if (teamsUrlError != null)
+                return $"Invalid Teams Webhook URL: {teamsUrlError}";
+
+            var headersError = ValidateWebhookCustomHeaders(candidate.WebhookCustomHeadersJson);
+            if (headersError != null)
+                return $"Invalid custom headers: {headersError}";
+
+            var channelsError = ValidateNotificationChannels(candidate.NotificationChannelsJson);
+            if (channelsError != null)
+                return $"Invalid notification channels: {channelsError}";
+
+            // Only validate the customer-supplied SAS URL when the tenant has actually selected
+            // the CustomerSas destination — a stale value left over from a prior CustomerSas
+            // configuration must not block a Hosted save (mirrors GetDiagnosticsUploadUrlFunction).
+            var diagDestination = Functions.Diagnostics.GetDiagnosticsUploadUrlFunction
+                .NormalizeDestination(candidate.DiagnosticsUploadDestination);
+            if (diagDestination == Functions.Diagnostics.GetDiagnosticsUploadUrlFunction.DestinationCustomerSas)
+            {
+                var diagSasError = SsrfGuard.ValidateAzureBlobSasUrlFormat(candidate.DiagnosticsBlobSasUrl);
+                if (diagSasError != null)
+                    return $"Invalid Diagnostics SAS URL: {diagSasError}";
+            }
+
+            // Retention cap (edition entitlement): non-GA callers may only set 7..cap days, and
+            // only when they actually CHANGED the value — a stored value predating the cap must
+            // not block unrelated saves. 0 (= infinite) is a GA-only escape hatch. Edition
+            // resolves from the STORED config.
+            if (!isGlobalAdmin && candidate.DataRetentionDays != existing.DataRetentionDays)
+            {
+                var cap = FeatureEntitlementCatalog
+                    .Get(TenantEntitlementService.ResolveEdition(existing, DateTime.UtcNow))
+                    .RetentionCapDays;
+                if (candidate.DataRetentionDays < 7 || candidate.DataRetentionDays > cap)
+                    return $"Data retention must be between 7 and {cap} days for your plan. Upgrade to Pro for up to 365 days.";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Validates the tenant contact address. Returns an error message, or null when valid/empty.
+        /// Empty is legitimate — it means we have no way to reach the tenant.
+        /// <para>
+        /// Deliberately not an RFC 5322 parser: the job is to reject values that are not addresses
+        /// at all. Specifically it rejects recipient lists (a comma would silently widen who receives
+        /// service notices), display-name forms, and control characters (which would let a caller
+        /// forge mail headers once this address is actually mailed).
+        /// </para>
+        /// </summary>
+        internal static string? ValidateContactEmail(string? email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                return null;
+
+            var trimmed = email.Trim();
+
+            if (trimmed.Length > MaxContactEmailLength)
+                return $"must be at most {MaxContactEmailLength} characters.";
+
+            foreach (var ch in trimmed)
+            {
+                if (char.IsControl(ch))
+                    return "must not contain control characters.";
+                if (char.IsWhiteSpace(ch) || ch == ',' || ch == ';' || ch == '<' || ch == '>')
+                    return "must be a single address, without spaces, separators or angle brackets.";
+            }
+
+            var at = trimmed.IndexOf('@');
+            if (at <= 0 || at != trimmed.LastIndexOf('@') || at == trimmed.Length - 1)
+                return "must contain a single \"@\" with text on both sides.";
+
+            // A bare host with no dot is unreachable from our sender, so it is a typo, not an address.
+            var domain = trimmed.Substring(at + 1);
+            if (!domain.Contains('.') || domain.StartsWith(".", StringComparison.Ordinal)
+                || domain.EndsWith(".", StringComparison.Ordinal))
+            {
+                return "the domain part must be a dotted host name.";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Validates the notification-channel list JSON. Returns an error message, or null when
+        /// valid/empty. Strict counterpart of the fail-soft <c>NotificationChannel.ParseList</c>:
+        /// entries the parser would silently drop (missing id, unknown provider) are rejected here
+        /// so a tenant admin gets feedback instead of a channel that never fires. Each channel's
+        /// URL and custom headers pass the same gates as the legacy single-webhook fields.
+        /// </summary>
+        internal static string? ValidateNotificationChannels(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+
+            if (json.Length > MaxNotificationChannelsJsonLength)
+                return $"too large (max {MaxNotificationChannelsJsonLength} characters).";
+
+            List<Shared.Models.Notifications.NotificationChannel>? channels;
+            try
+            {
+                channels = System.Text.Json.JsonSerializer.Deserialize<List<Shared.Models.Notifications.NotificationChannel>>(
+                    json, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return "not valid JSON.";
+            }
+
+            if (channels == null)
+                return "must be a JSON array of channels.";
+
+            if (channels.Count > Shared.Models.Notifications.NotificationChannel.MaxChannelsPerTenant)
+                return $"too many channels (max {Shared.Models.Notifications.NotificationChannel.MaxChannelsPerTenant}).";
+
+            var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var channel in channels)
+            {
+                if (channel == null || string.IsNullOrWhiteSpace(channel.Id))
+                    return "every channel needs an id.";
+                if (!ids.Add(channel.Id))
+                    return $"duplicate channel id \"{channel.Id}\".";
+
+                var label = string.IsNullOrWhiteSpace(channel.Name) ? channel.Id : channel.Name;
+
+                if (!Enum.IsDefined(typeof(Shared.Models.Notifications.WebhookProviderType), channel.ProviderType)
+                    || channel.ProviderType == (int)Shared.Models.Notifications.WebhookProviderType.None)
+                    return $"channel \"{label}\" has an invalid provider type.";
+
+                var urlError = SsrfGuard.ValidateWebhookUrlFormat(channel.Url);
+                if (urlError != null)
+                    return $"channel \"{label}\": {urlError}";
+
+                var headerError = ValidateWebhookCustomHeaders(channel.CustomHeadersJson);
+                if (headerError != null)
+                    return $"channel \"{label}\" headers: {headerError}";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Validates the generic-webhook custom-headers JSON. Returns an error message, or null when
+        /// valid/empty. Enforces a JSON object of string values, valid HTTP token names, no CR/LF
+        /// header-injection, and size caps. Restricted (framing/host/content) headers are not rejected
+        /// here — they are silently ignored at dispatch by TenantConfiguration.GetGenericWebhookHeaders().
+        /// </summary>
+        internal static string? ValidateWebhookCustomHeaders(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+
+            if (json.Length > MaxCustomHeadersJsonLength)
+                return $"too large (max {MaxCustomHeadersJsonLength} characters).";
+
+            System.Text.Json.JsonDocument doc;
+            try
+            {
+                doc = System.Text.Json.JsonDocument.Parse(json);
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return "not valid JSON.";
+            }
+
+            using (doc)
+            {
+                if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
+                    return "must be a JSON object of header name/value pairs.";
+
+                var count = 0;
+                foreach (var prop in doc.RootElement.EnumerateObject())
+                {
+                    if (++count > MaxCustomHeaderCount)
+                        return $"too many headers (max {MaxCustomHeaderCount}).";
+
+                    if (prop.Value.ValueKind != System.Text.Json.JsonValueKind.String)
+                        return $"header \"{prop.Name}\" must have a string value.";
+
+                    if (!IsValidHeaderName(prop.Name))
+                        return $"\"{prop.Name}\" is not a valid HTTP header name.";
+
+                    var value = prop.Value.GetString();
+                    if (value != null && (value.IndexOf('\r') >= 0 || value.IndexOf('\n') >= 0))
+                        return $"value for \"{prop.Name}\" must not contain line breaks.";
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>Validates an HTTP header name as an RFC 7230 token (no whitespace, controls, or separators).</summary>
+        private static bool IsValidHeaderName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return false;
+
+            foreach (var ch in name)
+            {
+                var isTokenChar =
+                    (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') ||
+                    "!#$%&'*+-.^_`|~".IndexOf(ch) >= 0;
+                if (!isTokenChar)
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Program.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Program.cs
@@ -232,6 +232,7 @@ builder.Services.AddHostedService<TableInitializerService>(); // Initialize all 
 // To add event streaming: chain .AddEventStreaming<EventHubPublisher>() after this call.
 builder.Services.AddTableStorageDataAccess();
 builder.Services.AddSingleton<TenantConfigurationService>();
+builder.Services.AddSingleton<TenantConfigPatchService>();
 builder.Services.AddSingleton<AdminConfigurationService>();
 builder.Services.AddSingleton<AppHomingService>();
 builder.Services.AddSingleton<TenantEntitlementService>();

--- a/src/Backend/AutopilotMonitor.Functions/Security/EndpointAccessPolicyCatalog.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Security/EndpointAccessPolicyCatalog.cs
@@ -390,6 +390,14 @@ public static class EndpointAccessPolicyCatalog
         new("PUT",    "global/config",             EndpointPolicy.GlobalAdminOnly),
         new("POST",   "global/config",             EndpointPolicy.GlobalAdminOnly),
         new("GET",    "config/all",                EndpointPolicy.GlobalReadOrDelegatedSubset),
+        // Transactional field-level config writes + snapshot list/revert (MCP-first surface).
+        // GlobalAdminOnly for now; phase 2 widens these three lines to TenantAdminOrGA (own row)
+        // and a delegated-admin write policy — the service's caller-tier field deny-lists and
+        // TenantScoping.RouteParam already carry the per-tenant guardrail. The backups GET is
+        // metadata-only (masked diff, never the raw EntityJson snapshot).
+        new("PATCH",  "config/{tenantId}/fields",  EndpointPolicy.GlobalAdminOnly, TenantScoping.RouteParam),
+        new("GET",    "config/{tenantId}/backups", EndpointPolicy.GlobalAdminOnly, TenantScoping.RouteParam),
+        new("POST",   "config/{tenantId}/revert",  EndpointPolicy.GlobalAdminOnly, TenantScoping.RouteParam),
         new("GET",    "auth/global-admins",        EndpointPolicy.GlobalReadOrAdmin),
         new("POST",   "auth/global-admins",        EndpointPolicy.GlobalAdminOnly),
         new("DELETE", "auth/global-admins/{upn}",  EndpointPolicy.GlobalAdminOnly),

--- a/src/Backend/AutopilotMonitor.Functions/Services/AppHomingService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/AppHomingService.cs
@@ -159,7 +159,7 @@ namespace AutopilotMonitor.Functions.Services
 
             config.HomedAppClientId = normalizedTarget;
             config.UpdatedBy = actorUpn;
-            await _tenantConfigService.SaveConfigurationAsync(config);
+            await _tenantConfigService.SaveConfigurationAsync(config, "app-homing", reason);
 
             _logger.LogWarning(
                 "Tenant {TenantId} app-reg homing flipped: {Old} -> {New} (by {User}, reason {Reason}, forced {Forced})",

--- a/src/Backend/AutopilotMonitor.Functions/Services/Offboarding/TenantOffboardingHandler.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/Offboarding/TenantOffboardingHandler.cs
@@ -83,6 +83,11 @@ namespace AutopilotMonitor.Functions.Services.Offboarding
             // whole-row deletion besides chain-emptying.
             Constants.TableNames.DeviceHistories,
             Constants.TableNames.DeviceJourneyAggregates,
+            // Pre-write config snapshots (PK=tenantId). Wiped in the bulk phase; the
+            // TenantConfiguration row itself is deleted LAST via SafeWipe (a delete, not a
+            // save), so the wipe cannot re-create a snapshot afterwards. The admin-config
+            // "GlobalConfig" partition never matches a tenant GUID and survives untouched.
+            Constants.TableNames.ConfigurationBackups,
         };
 
         // Plan §6.4 — composite-PK "{tenantId}_..." wipes (Variant A range).

--- a/src/Backend/AutopilotMonitor.Functions/Services/TenantConfigPatchService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TenantConfigPatchService.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using AutopilotMonitor.Functions.DataAccess.TableStorage;
+using AutopilotMonitor.Functions.Helpers;
+using AutopilotMonitor.Shared;
+using AutopilotMonitor.Shared.DataAccess;
+using AutopilotMonitor.Shared.Models;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AutopilotMonitor.Functions.Services
+{
+    /// <summary>Which authority tier is driving a config patch/revert — selects the field deny-list.</summary>
+    public enum TenantConfigCallerTier
+    {
+        GlobalAdmin,
+        // Phase 2 (not wired yet): tenant admins / delegated (MSP) admins get the stricter
+        // deny-list that additionally blocks the GA-only toggles. The lists and tests exist
+        // now so the later rollout is a policy-catalog flip, not new logic.
+        TenantAdmin,
+        DelegatedAdmin,
+    }
+
+    public enum PatchFailure
+    {
+        None,
+        NotFound,
+        InvalidField,
+        ValidationFailed,
+        BackupFailed,
+        WriteConflict,
+        DriftRolledBack,
+        DriftRollbackFailed,
+    }
+
+    /// <summary>
+    /// Result of a transactional patch/revert. Never carries the full configuration —
+    /// responses reach model context via MCP, so only field NAMES and the masked diff
+    /// (ConfigDiffHelper output: secrets masked, values truncated) are exposed.
+    /// </summary>
+    public sealed record PatchOutcome(
+        bool Success,
+        PatchFailure Failure,
+        string? Error,
+        string? BackupId,
+        IReadOnlyCollection<string> AppliedFields,
+        Dictionary<string, string>? MaskedDiff,
+        IReadOnlyCollection<string>? Drift)
+    {
+        internal static PatchOutcome Fail(PatchFailure failure, string error, string? backupId = null, IReadOnlyCollection<string>? drift = null)
+            => new(false, failure, error, backupId, Array.Empty<string>(), null, drift);
+    }
+
+    /// <summary>
+    /// Transactional field-level writes against a tenant's configuration row:
+    /// fresh ETag read → field gate → patch onto a clone → shared validation →
+    /// fail-CLOSED backup → conditional replace (CAS) → fresh re-read →
+    /// verify that EXACTLY the intended fields changed → automatic rollback on drift.
+    /// <para>
+    /// The verify step is not paranoia theatre: with CAS a concurrent writer cannot
+    /// corrupt the row, but a Store/Map serialization asymmetry (a field present in one
+    /// converter and not the other) silently mangles unrelated fields on every save —
+    /// this flow detects that as unexpected drift and rolls back.
+    /// </para>
+    /// </summary>
+    public class TenantConfigPatchService
+    {
+        internal const int MaxCasAttempts = 3;
+
+        private readonly IConfigRepository _configRepo;
+        private readonly IConfigBackupRepository _backupRepo;
+        private readonly TenantConfigurationService _configService;
+        private readonly IMaintenanceRepository _maintenanceRepo;
+        private readonly ILogger<TenantConfigPatchService> _logger;
+
+        public TenantConfigPatchService(
+            IConfigRepository configRepo,
+            IConfigBackupRepository backupRepo,
+            TenantConfigurationService configService,
+            IMaintenanceRepository maintenanceRepo,
+            ILogger<TenantConfigPatchService> logger)
+        {
+            _configRepo = configRepo;
+            _backupRepo = backupRepo;
+            _configService = configService;
+            _maintenanceRepo = maintenanceRepo;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Fields no caller may write through the patch endpoint. Identity/plumbing, fields
+        /// with dedicated endpoints (plan/trial), and system-written provenance:
+        /// HomedAppClientId caused the 2026-07-31 prod incident when a stale round-trip
+        /// reverted it — only the app-homing flow writes it; LastAuthClientId*/OnboardedBy/
+        /// OnboardedAt are AuthFunction-owned; LastUpdated/UpdatedBy are stamped server-side.
+        /// </summary>
+        internal static readonly HashSet<string> BaseDeniedFields = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "TenantId", "DomainName", "PartitionKey", "RowKey", "Timestamp", "ETag",
+            "LastUpdated", "UpdatedBy", "OnboardedAt", "OnboardedBy",
+            "HomedAppClientId", "LastAuthClientId", "LastAuthClientIdSince",
+            "PlanTier", "TrialExpiresUtc", "TrialStartedUtc", "TrialConsumed", "TrialGrantedBy",
+        };
+
+        /// <summary>
+        /// Additional deny-list for non-GA tiers (phase 2): the GA-only toggles the PUT
+        /// endpoint silently reverts for tenant admins are an explicit 400 here.
+        /// </summary>
+        internal static readonly HashSet<string> GaOnlyFields = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Disabled", "DisabledReason", "DisabledUntil",
+            "AllowInsecureAgentRequests", "BootstrapTokenEnabled",
+            "UnrestrictedModeEnabled", "EntraAppRolesEnabled",
+            "CustomRateLimitRequestsPerMinute", "CustomUserRateLimitRequestsPerMinute",
+            "ValidateDeviceAssociation", "MaxNdjsonPayloadSizeMB",
+        };
+
+        /// <summary>
+        /// Fields a revert preserves from the CURRENT row unless the caller explicitly opts
+        /// into restoring them (GA-only flag): time-traveling plan/trial or app-homing state
+        /// via an old snapshot is almost never the intent and was the exact 07-31 failure mode.
+        /// TenantId/DomainName are ALWAYS taken from current, flag or not.
+        /// </summary>
+        internal static readonly HashSet<string> RevertProtectedFields = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "HomedAppClientId", "LastAuthClientId", "LastAuthClientIdSince",
+            "OnboardedBy", "OnboardedAt",
+            "PlanTier", "TrialExpiresUtc", "TrialStartedUtc", "TrialConsumed", "TrialGrantedBy",
+        };
+
+        private static readonly Dictionary<string, PropertyInfo> ModelProperties =
+            typeof(TenantConfiguration)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanWrite && p.GetIndexParameters().Length == 0)
+                .ToDictionary(p => p.Name, p => p, StringComparer.OrdinalIgnoreCase);
+
+        public async Task<PatchOutcome> ApplyFieldPatchAsync(
+            string tenantId, JObject fields, string updatedBy, string source, string? reason,
+            TenantConfigCallerTier callerTier = TenantConfigCallerTier.GlobalAdmin)
+        {
+            if (fields == null || !fields.Properties().Any())
+                return PatchOutcome.Fail(PatchFailure.InvalidField, "No fields provided — nothing to patch.");
+
+            // Field gate BEFORE any storage work: reject unknown and non-writable keys with
+            // the offending name, so a caller (or a model driving the MCP tool) can self-correct.
+            var denied = callerTier == TenantConfigCallerTier.GlobalAdmin
+                ? BaseDeniedFields
+                : new HashSet<string>(BaseDeniedFields.Concat(GaOnlyFields), StringComparer.OrdinalIgnoreCase);
+            foreach (var prop in fields.Properties())
+            {
+                if (!ModelProperties.ContainsKey(prop.Name))
+                    return PatchOutcome.Fail(PatchFailure.InvalidField, $"Unknown field \"{prop.Name}\".");
+                if (denied.Contains(prop.Name))
+                    return PatchOutcome.Fail(PatchFailure.InvalidField,
+                        $"Field \"{prop.Name}\" is not writable via the field patch (identity, plan/trial, or system-owned — use the dedicated endpoint if one exists).");
+                if (ContainsRedactedPlaceholder(prop.Value))
+                    return PatchOutcome.Fail(PatchFailure.InvalidField,
+                        $"Field \"{prop.Name}\" carries the \"{Constants.RedactedSecretPlaceholder}\" placeholder — a redacted read must never be written back. Provide the real value.");
+            }
+
+            for (var attempt = 1; attempt <= MaxCasAttempts; attempt++)
+            {
+                var read = await _configRepo.GetTenantConfigurationWithEtagAsync(tenantId);
+                if (read == null)
+                    return PatchOutcome.Fail(PatchFailure.NotFound, $"Tenant {tenantId} has no configuration row.");
+                var (initial, etag) = read.Value;
+
+                // Patch onto a deep clone; MissingMemberHandling.Error is belt-and-braces on
+                // top of the key gate above. JSON null = explicit clear; omitted = untouched;
+                // camelCase input binds case-insensitively to the PascalCase model.
+                var clone = DeepClone(initial);
+                try
+                {
+                    JsonConvert.PopulateObject(fields.ToString(), clone, new JsonSerializerSettings
+                    {
+                        MissingMemberHandling = MissingMemberHandling.Error,
+                    });
+                }
+                catch (JsonException ex)
+                {
+                    return PatchOutcome.Fail(PatchFailure.InvalidField, $"Field patch failed to apply: {ex.Message}");
+                }
+
+                // Same normalization as the PUT: never store surrounding whitespace, and an
+                // all-whitespace submission clears the field.
+                clone.ContactEmail = string.IsNullOrWhiteSpace(clone.ContactEmail) ? null : clone.ContactEmail.Trim();
+
+                // The PUT silently flips UnrestrictedMode off when the GA gate is off. A silent
+                // flip would poison the exactly-these-fields verify below, so here the
+                // inconsistency is an explicit error instead.
+                if (clone.UnrestrictedMode && !clone.UnrestrictedModeEnabled)
+                    return PatchOutcome.Fail(PatchFailure.ValidationFailed,
+                        "UnrestrictedMode cannot be enabled while UnrestrictedModeEnabled (the GA gate) is off.");
+
+                var validationError = TenantConfigValidation.ValidateModel(
+                    clone, initial, isGlobalAdmin: callerTier == TenantConfigCallerTier.GlobalAdmin);
+                if (validationError != null)
+                    return PatchOutcome.Fail(PatchFailure.ValidationFailed, validationError);
+
+                // Intended change set is COMPUTED, not taken from the request keys: a patched
+                // key whose value equals the stored value produces no diff and must not be
+                // "expected" by the verify step. The server-side stamps are excluded — the
+                // write overwrites them regardless, and the verify treats them as allowed.
+                var expected = ConfigPropertyComparer.GetChangedPropertyNames(initial, clone);
+                expected.Remove("LastUpdated");
+                expected.Remove("UpdatedBy");
+                if (expected.Count == 0)
+                    return new PatchOutcome(true, PatchFailure.None, null, null,
+                        Array.Empty<string>(), new Dictionary<string, string>(), null);
+
+                var outcome = await WriteVerifiedAsync(
+                    tenantId, initial, etag, clone, expected, updatedBy, source, reason,
+                    auditAction: "PATCH",
+                    retriesLeft: MaxCasAttempts - attempt);
+                if (outcome != null)
+                    return outcome;
+                await NextAttemptDelayAsync();
+            }
+
+            return PatchOutcome.Fail(PatchFailure.WriteConflict,
+                $"Concurrent configuration writes for tenant {tenantId} — {MaxCasAttempts} conditional-write attempts lost the race. Retry shortly.");
+        }
+
+        public async Task<PatchOutcome> RevertAsync(
+            string tenantId, string? backupId, bool includeProtectedFields,
+            string updatedBy, string source, string? reason,
+            TenantConfigCallerTier callerTier = TenantConfigCallerTier.GlobalAdmin)
+        {
+            var backup = backupId != null
+                ? await _backupRepo.TryGetAsync(tenantId, backupId)
+                : (await _backupRepo.ListByPartitionAsync(tenantId, max: 1)).FirstOrDefault();
+            if (backup == null)
+                return PatchOutcome.Fail(PatchFailure.NotFound,
+                    backupId != null
+                        ? $"Backup \"{backupId}\" not found for tenant {tenantId}."
+                        : $"Tenant {tenantId} has no configuration backups yet.");
+
+            TenantConfiguration target;
+            try
+            {
+                target = TableConfigRepository.ConvertFromTenantTableEntity(
+                    RehydrateTenantConfigEntity(backup.EntityJson, tenantId));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Config backup {BackupId} for tenant {TenantId} failed to rehydrate", backup.RowKey, tenantId);
+                return PatchOutcome.Fail(PatchFailure.ValidationFailed,
+                    $"Backup \"{backup.RowKey}\" could not be rehydrated — not reverting.");
+            }
+
+            for (var attempt = 1; attempt <= MaxCasAttempts; attempt++)
+            {
+                var read = await _configRepo.GetTenantConfigurationWithEtagAsync(tenantId);
+                if (read == null)
+                    return PatchOutcome.Fail(PatchFailure.NotFound, $"Tenant {tenantId} has no configuration row.");
+                var (current, etag) = read.Value;
+
+                var candidate = DeepClone(target);
+                // Identity is never restored from a snapshot; protected/system-owned fields
+                // only with the explicit GA opt-in.
+                candidate.TenantId = current.TenantId;
+                candidate.DomainName = current.DomainName;
+                if (!includeProtectedFields)
+                {
+                    foreach (var name in RevertProtectedFields)
+                    {
+                        var prop = ModelProperties[name];
+                        prop.SetValue(candidate, prop.GetValue(current));
+                    }
+                }
+
+                // A snapshot predating a validation rule must not bypass it on the way back in.
+                var validationError = TenantConfigValidation.ValidateModel(
+                    candidate, current, isGlobalAdmin: callerTier == TenantConfigCallerTier.GlobalAdmin);
+                if (validationError != null)
+                    return PatchOutcome.Fail(PatchFailure.ValidationFailed,
+                        $"Backup \"{backup.RowKey}\" no longer passes validation: {validationError}");
+
+                // Bookkeeping stamps are excluded: the write re-stamps them anyway, and a
+                // snapshot differing ONLY in LastUpdated/UpdatedBy is a no-op revert.
+                var expected = ConfigPropertyComparer.GetChangedPropertyNames(current, candidate);
+                expected.Remove("LastUpdated");
+                expected.Remove("UpdatedBy");
+                if (expected.Count == 0)
+                    return new PatchOutcome(true, PatchFailure.None, null, null,
+                        Array.Empty<string>(), new Dictionary<string, string>(), null);
+
+                var outcome = await WriteVerifiedAsync(
+                    tenantId, current, etag, candidate, expected, updatedBy, source,
+                    reason ?? $"revert to backup {backup.RowKey}",
+                    auditAction: "REVERT",
+                    retriesLeft: MaxCasAttempts - attempt);
+                if (outcome != null)
+                    return outcome;
+                await NextAttemptDelayAsync();
+            }
+
+            return PatchOutcome.Fail(PatchFailure.WriteConflict,
+                $"Concurrent configuration writes for tenant {tenantId} — {MaxCasAttempts} conditional-write attempts lost the race. Retry shortly.");
+        }
+
+        /// <summary>
+        /// Backup (fail-closed) → stamp → CAS write → cache invalidation → fresh re-read →
+        /// exactly-these-fields verify → rollback on drift → audit. Returns null when the CAS
+        /// write lost the race and the caller should re-read and retry.
+        /// </summary>
+        private async Task<PatchOutcome?> WriteVerifiedAsync(
+            string tenantId, TenantConfiguration initial, string etag, TenantConfiguration candidate,
+            HashSet<string> expected, string updatedBy, string source, string? reason,
+            string auditAction, int retriesLeft)
+        {
+            // Fail-CLOSED backup of the state we are about to replace. The CAS ETag guarantees
+            // the row still IS this state when the write lands; a lost race at worst leaves a
+            // duplicate snapshot that pruning ages out.
+            string backupId;
+            try
+            {
+                var snapshot = TableConfigRepository.BuildBackupEntry(
+                    TableConfigRepository.ConvertToTenantTableEntity(initial),
+                    tenantId, updatedBy, source, reason,
+                    System.Text.Json.JsonSerializer.Serialize(ConfigDiffHelper.GetChanges(initial, candidate)));
+                await _backupRepo.UpsertAsync(snapshot);
+                backupId = snapshot.RowKey;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Fail-closed config backup failed for tenant {TenantId} — refusing to write", tenantId);
+                return PatchOutcome.Fail(PatchFailure.BackupFailed,
+                    "Backup storage is unavailable — refusing to write without a pre-write snapshot. Retry later.");
+            }
+
+            candidate.LastUpdated = DateTime.UtcNow;
+            candidate.UpdatedBy = updatedBy;
+
+            var replaced = await _configRepo.TryReplaceTenantConfigurationAsync(candidate, etag);
+            _configService.InvalidateCache(tenantId);
+            if (!replaced)
+            {
+                _logger.LogInformation(
+                    "Config CAS write for tenant {TenantId} lost the race ({RetriesLeft} retries left)",
+                    tenantId, retriesLeft);
+                return null; // caller re-reads and retries
+            }
+
+            // Fresh re-read via the repo (never the cache) + exactly-these-fields verify.
+            var reread = await _configRepo.GetTenantConfigurationWithEtagAsync(tenantId);
+            if (reread == null)
+            {
+                // Row vanished between write and verify (offboarding). Nothing to roll back onto.
+                return PatchOutcome.Fail(PatchFailure.DriftRollbackFailed,
+                    $"Configuration row for tenant {tenantId} disappeared after the write (offboarding?). Backup {backupId} holds the pre-write state.",
+                    backupId);
+            }
+
+            var actual = ConfigPropertyComparer.GetChangedPropertyNames(initial, reread.Value.Config);
+            var expectedFinal = new HashSet<string>(expected, StringComparer.OrdinalIgnoreCase) { "LastUpdated", "UpdatedBy" };
+            // actual must cover every intended field AND introduce nothing beyond them (+stamps).
+            var missing = expected.Where(f => !actual.Contains(f)).ToList();
+            var unexpected = actual.Where(f => !expectedFinal.Contains(f)).ToList();
+            if (missing.Count > 0 || unexpected.Count > 0)
+            {
+                var drift = missing.Select(f => $"missing:{f}").Concat(unexpected.Select(f => $"unexpected:{f}")).ToList();
+                _logger.LogError(
+                    "Config write verification FAILED for tenant {TenantId} (action {Action}): {Drift} — rolling back",
+                    tenantId, auditAction, string.Join(", ", drift));
+
+                // Roll back to the initial state, conditional on the post-write ETag so a
+                // concurrent writer that slipped in after our write is never clobbered.
+                var rolledBack = await _configRepo.TryReplaceTenantConfigurationAsync(initial, reread.Value.ETag);
+                _configService.InvalidateCache(tenantId);
+                if (!rolledBack)
+                    return PatchOutcome.Fail(PatchFailure.DriftRollbackFailed,
+                        $"Write verification failed ({string.Join(", ", drift)}) and the rollback lost a concurrent-write race. Restore manually from backup {backupId}.",
+                        backupId, drift);
+
+                return PatchOutcome.Fail(PatchFailure.DriftRolledBack,
+                    $"Write verification failed — the row changed beyond the intended fields ({string.Join(", ", drift)}). The write was rolled back; nothing persisted. This usually means Store/Map serialization drift — investigate before retrying.",
+                    backupId, drift);
+            }
+
+            var maskedDiff = ConfigDiffHelper.GetChanges(initial, reread.Value.Config);
+            var auditDetails = new Dictionary<string, string>(maskedDiff) { ["BackupId"] = backupId };
+            await _maintenanceRepo.LogAuditEntryAsync(
+                tenantId, auditAction, "TenantConfiguration", tenantId, updatedBy, auditDetails);
+
+            var applied = expected.OrderBy(f => f, StringComparer.OrdinalIgnoreCase).ToList();
+            return new PatchOutcome(true, PatchFailure.None, null, backupId, applied, maskedDiff, null);
+        }
+
+        /// <summary>
+        /// Schema-aware rehydration of a raw EntityJson snapshot back into a TableEntity.
+        /// Strings are converted to DateTime ONLY for columns the model declares as DateTime —
+        /// an arbitrary string field that merely looks like a date stays a string.
+        /// </summary>
+        internal static TableEntity RehydrateTenantConfigEntity(string entityJson, string tenantId)
+        {
+            var dateColumns = ModelProperties.Values
+                .Where(p => p.PropertyType == typeof(DateTime) || p.PropertyType == typeof(DateTime?))
+                .Select(p => p.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            using var doc = System.Text.Json.JsonDocument.Parse(entityJson);
+            var entity = new TableEntity(tenantId, "config");
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                if (prop.Name is "PartitionKey" or "RowKey") continue;
+                entity[prop.Name] = prop.Value.ValueKind switch
+                {
+                    System.Text.Json.JsonValueKind.Null => null,
+                    System.Text.Json.JsonValueKind.True => true,
+                    System.Text.Json.JsonValueKind.False => false,
+                    System.Text.Json.JsonValueKind.Number =>
+                        prop.Value.TryGetInt32(out var i) ? i
+                        : prop.Value.TryGetInt64(out var l) ? (object)l
+                        : prop.Value.GetDouble(),
+                    System.Text.Json.JsonValueKind.String =>
+                        dateColumns.Contains(prop.Name) && prop.Value.TryGetDateTimeOffset(out var dto)
+                            ? dto.UtcDateTime
+                            : prop.Value.GetString(),
+                    _ => prop.Value.GetRawText(),
+                };
+            }
+            return entity;
+        }
+
+        private static bool ContainsRedactedPlaceholder(JToken value)
+            => value.Type == JTokenType.String
+               && ((string?)value)?.Contains(Constants.RedactedSecretPlaceholder, StringComparison.Ordinal) == true;
+
+        private static TenantConfiguration DeepClone(TenantConfiguration config)
+            => JsonConvert.DeserializeObject<TenantConfiguration>(JsonConvert.SerializeObject(config))!;
+
+        // Tiny spacing between CAS retries; keeps the loop honest without a TimeProvider dance.
+        private static Task NextAttemptDelayAsync() => Task.Delay(TimeSpan.FromMilliseconds(150));
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Services/TenantConfigurationService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TenantConfigurationService.cs
@@ -93,7 +93,15 @@ namespace AutopilotMonitor.Functions.Services
         /// on failure the caller may have mutated the cached instance in place (plan/trial endpoints),
         /// which must not linger as phantom-saved state for the 5-minute TTL.
         /// </summary>
-        public virtual async Task SaveConfigurationAsync(TenantConfiguration config)
+        public virtual Task SaveConfigurationAsync(TenantConfiguration config)
+            => SaveConfigurationAsync(config, backupSource: null, backupReason: null);
+
+        /// <summary>
+        /// Overload (not optional parameters — Moq expression trees, CS0854) that tags the
+        /// pre-write backup snapshot with the write path and intent.
+        /// </summary>
+        public virtual async Task SaveConfigurationAsync(
+            TenantConfiguration config, string? backupSource, string? backupReason)
         {
             if (config == null || string.IsNullOrEmpty(config.TenantId))
             {
@@ -104,7 +112,7 @@ namespace AutopilotMonitor.Functions.Services
             {
                 config.LastUpdated = DateTime.UtcNow;
 
-                var saved = await _configRepo.SaveTenantConfigurationAsync(config);
+                var saved = await _configRepo.SaveTenantConfigurationAsync(config, backupSource, backupReason);
                 if (!saved)
                 {
                     throw new InvalidOperationException(

--- a/src/McpServer/autopilot-monitor-mcp/src/__tests__/config-write-tools.test.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/__tests__/config-write-tools.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the tenant-config write surface (get_tenant_config /
+ * update_tenant_config / list_tenant_config_backups / revert_tenant_config):
+ *  - the redacted-view pin: get_tenant_config must ALWAYS request ?view=redacted
+ *    (this is the guard that keeps clear-text webhook/SAS secrets out of model
+ *    context — the backend serves a GA the full secrets without it)
+ *  - request shapes of the mutating tools (method, body, path encoding)
+ *  - GUID validation on tenantId (path-traversal guard)
+ *
+ * apiFetch is mocked so these run with no backend / token.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+
+vi.mock('../client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../client.js')>();
+  return { ...actual, apiFetch: apiFetchMock };
+});
+
+import { registerAdminTools } from '../tools/admin.js';
+import { TenantGuidSchema } from '../tools/shared.js';
+
+type Handler = (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+
+function captureToolHandlers(ga: boolean, strictGa: boolean, delegated = false): Record<string, Handler> {
+  const handlers: Record<string, Handler> = {};
+  const fake = { registerTool: (name: string, _def: unknown, handler: Handler) => { handlers[name] = handler; } };
+  registerAdminTools(fake as never, ga, strictGa, delegated);
+  return handlers;
+}
+
+const TENANT = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+describe('config-write tool registration', () => {
+  it('all four tools exist for a strict Global Admin only', () => {
+    const gaHandlers = captureToolHandlers(true, true);
+    const readerHandlers = captureToolHandlers(true, false);
+    const tenantHandlers = captureToolHandlers(false, false);
+    for (const name of [
+      'get_tenant_config', 'update_tenant_config',
+      'list_tenant_config_backups', 'revert_tenant_config',
+    ]) {
+      expect(gaHandlers, `${name} missing for GA`).toHaveProperty(name);
+      expect(readerHandlers, `${name} must be hidden from a Global Reader`).not.toHaveProperty(name);
+      expect(tenantHandlers, `${name} must be hidden from a tenant user`).not.toHaveProperty(name);
+    }
+  });
+});
+
+describe('get_tenant_config — forced redaction pin', () => {
+  beforeEach(() => apiFetchMock.mockReset());
+
+  it('always requests ?view=redacted — secrets must never reach model context', async () => {
+    apiFetchMock.mockResolvedValueOnce({ tenantId: TENANT, teamsWebhookUrl: '***REDACTED***' });
+    await captureToolHandlers(true, true).get_tenant_config({ tenantId: TENANT });
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    const path = apiFetchMock.mock.calls[0][0] as string;
+    expect(path).toBe(`/api/config/${TENANT}?view=redacted`);
+  });
+});
+
+describe('update_tenant_config — request shape', () => {
+  beforeEach(() => apiFetchMock.mockReset());
+
+  it('PATCHes the fields endpoint with { fields, reason }', async () => {
+    apiFetchMock.mockResolvedValueOnce({ success: true, appliedFields: ['DataRetentionDays'], backupId: 'b1' });
+    await captureToolHandlers(true, true).update_tenant_config({
+      tenantId: TENANT,
+      fields: { dataRetentionDays: 90 },
+      reason: 'retention bump',
+    });
+
+    const [path, options] = apiFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe(`/api/config/${TENANT}/fields`);
+    expect(options.method).toBe('PATCH');
+    expect(JSON.parse(options.body as string)).toEqual({
+      fields: { dataRetentionDays: 90 },
+      reason: 'retention bump',
+    });
+  });
+});
+
+describe('revert_tenant_config — request shape', () => {
+  beforeEach(() => apiFetchMock.mockReset());
+
+  it('POSTs the revert endpoint; includeProtectedFields defaults to false', async () => {
+    apiFetchMock.mockResolvedValueOnce({ success: true });
+    await captureToolHandlers(true, true).revert_tenant_config({
+      tenantId: TENANT,
+      reason: 'undo bad change',
+    });
+
+    const [path, options] = apiFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe(`/api/config/${TENANT}/revert`);
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body as string)).toEqual({
+      backupId: undefined,
+      includeProtectedFields: false,
+      reason: 'undo bad change',
+    });
+  });
+
+  it('passes backupId and an explicit includeProtectedFields through', async () => {
+    apiFetchMock.mockResolvedValueOnce({ success: true });
+    await captureToolHandlers(true, true).revert_tenant_config({
+      tenantId: TENANT,
+      backupId: '0001_abcd1234',
+      includeProtectedFields: true,
+      reason: 'full restore incl. plan',
+    });
+
+    const body = JSON.parse((apiFetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.backupId).toBe('0001_abcd1234');
+    expect(body.includeProtectedFields).toBe(true);
+  });
+});
+
+describe('list_tenant_config_backups — request shape', () => {
+  beforeEach(() => apiFetchMock.mockReset());
+
+  it('GETs the backups endpoint, forwarding max when provided', async () => {
+    apiFetchMock.mockResolvedValue({ tenantId: TENANT, backups: [] });
+    const handlers = captureToolHandlers(true, true);
+
+    await handlers.list_tenant_config_backups({ tenantId: TENANT });
+    expect(apiFetchMock.mock.calls[0][0]).toBe(`/api/config/${TENANT}/backups`);
+
+    await handlers.list_tenant_config_backups({ tenantId: TENANT, max: 5 });
+    expect(apiFetchMock.mock.calls[1][0]).toBe(`/api/config/${TENANT}/backups?max=5`);
+  });
+});
+
+describe('tenantId GUID validation (path-traversal guard)', () => {
+  it('TenantGuidSchema rejects traversal / garbage values', () => {
+    for (const bad of ['../admin/foo', 'not-a-guid', '', `${TENANT}/extra`]) {
+      expect(TenantGuidSchema.safeParse(bad).success, `"${bad}" must be rejected`).toBe(false);
+    }
+    expect(TenantGuidSchema.safeParse(TENANT).success).toBe(true);
+    expect(TenantGuidSchema.safeParse(TENANT.toUpperCase()).success).toBe(true);
+  });
+});

--- a/src/McpServer/autopilot-monitor-mcp/src/__tests__/tools-catalog-order.test.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/__tests__/tools-catalog-order.test.ts
@@ -128,6 +128,7 @@ describe('role catalog snapshot — privilege-leak guard', () => {
     'get_session_events',
     'get_session_summary',
     'get_software_inventory',
+    'get_tenant_config',
     // Available to every role: backed by MemberRead endpoints (tenant) with role-aware
     // routing to the GlobalReadOrAdmin variant — same placement as get_app_install_metrics.
     'get_time_attribution',
@@ -136,16 +137,19 @@ describe('role catalog snapshot — privilege-leak guard', () => {
     'list_blocked_devices',
     'list_session_reports',
     'list_tables',
+    'list_tenant_config_backups',
     'list_tenants',
     'query_backend_logs',
     'query_raw_events',
     'query_raw_sessions',
     'query_table',
+    'revert_tenant_config',
     'search_events',
     'search_knowledge',
     'search_sessions',
     'search_sessions_by_cve',
     'search_sessions_by_event',
+    'update_tenant_config',
   ];
 
   // ── Named difference lists (each a deliberate role-boundary decision). ──
@@ -154,19 +158,35 @@ describe('role catalog snapshot — privilege-leak guard', () => {
   // config redaction would otherwise hide). strictGa gate.
   const RAW_GA_STRICT = ['list_tables', 'query_backend_logs', 'query_table'];
 
+  // Tenant-config write surface (+ its full-config read and backup list): strictGa
+  // only, matching the GlobalAdminOnly backend routes. A read-only Global Reader must
+  // see NONE of these — not even get_tenant_config (redacted or not, the full
+  // operational config is a GA surface; Readers use list_tenants' keep-list view).
+  const CONFIG_WRITE_GA_STRICT = [
+    'get_tenant_config',
+    'list_tenant_config_backups',
+    'revert_tenant_config',
+    'update_tenant_config',
+  ];
+
   // Platform-only tools: a non-platform caller (tenant or delegated) gets no
-  // cross-fleet aggregate surface at all. Superset of RAW_GA_STRICT (those are
-  // also platform-only) plus the curated cross-tenant aggregates.
+  // cross-fleet aggregate surface at all. Superset of RAW_GA_STRICT and
+  // CONFIG_WRITE_GA_STRICT (those are also platform-only) plus the curated
+  // cross-tenant aggregates.
   const PLATFORM_ONLY = [
     'get_api_usage',
     'get_ops_events',
     'get_platform_metrics',
+    'get_tenant_config',
     'list_blocked_devices',
     'list_session_reports',
     'list_tables',
+    'list_tenant_config_backups',
     'list_tenants',
     'query_backend_logs',
     'query_table',
+    'revert_tenant_config',
+    'update_tenant_config',
   ];
 
   // Deltas between a plain tenant user and a delegated (MSP) caller: the global
@@ -182,8 +202,9 @@ describe('role catalog snapshot — privilege-leak guard', () => {
     expect(registeredToolNames(true, true)).toEqual(GA_FULL);
   });
 
-  it('Global Reader = GA minus the secret-bearing raw tools (strictGa split)', () => {
-    expect(registeredToolNames(true, false)).toEqual(without(GA_FULL, RAW_GA_STRICT));
+  it('Global Reader = GA minus the secret-bearing raw tools and the config-write surface (strictGa split)', () => {
+    expect(registeredToolNames(true, false)).toEqual(
+      without(GA_FULL, [...RAW_GA_STRICT, ...CONFIG_WRITE_GA_STRICT]));
   });
 
   it('tenant user = GA minus all platform-only tools', () => {
@@ -200,6 +221,7 @@ describe('role catalog snapshot — privilege-leak guard', () => {
   it('every difference-list entry is a real GA tool', () => {
     for (const [label, list] of [
       ['RAW_GA_STRICT', RAW_GA_STRICT],
+      ['CONFIG_WRITE_GA_STRICT', CONFIG_WRITE_GA_STRICT],
       ['PLATFORM_ONLY', PLATFORM_ONLY],
       ['DELEGATED_HIDDEN', DELEGATED_HIDDEN],
       ['DELEGATED_ADDED', DELEGATED_ADDED],
@@ -214,5 +236,10 @@ describe('role catalog snapshot — privilege-leak guard', () => {
     // (and enforces) that the Reader split never re-exposes a tenant-hidden tool.
     const leaked = RAW_GA_STRICT.filter((n) => !PLATFORM_ONLY.includes(n));
     expect(leaked, 'a raw GA-strict tool is not also marked platform-only').toEqual([]);
+  });
+
+  it('the config-write tools are a subset of the platform-only tools', () => {
+    const leaked = CONFIG_WRITE_GA_STRICT.filter((n) => !PLATFORM_ONLY.includes(n));
+    expect(leaked, 'a config-write GA-strict tool is not also marked platform-only').toEqual([]);
   });
 });

--- a/src/McpServer/autopilot-monitor-mcp/src/index.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/index.ts
@@ -218,7 +218,7 @@ const DOCS = docsIndex ? { vector: docsIndex, sections: docSections(docsDocs) } 
 // Reader) sees the cross-tenant scope hint. A normal tenant user gets
 // instructions with no mention of cross-tenant capability at all — the surface
 // is scoped to what they can actually do.
-function buildInstructions(ga: boolean, delegated: boolean, managedTenants: string[], homeTenantId?: string): string {
+function buildInstructions(ga: boolean, strictGa: boolean, delegated: boolean, managedTenants: string[], homeTenantId?: string): string {
   // Delegated (MSP) callers get a tenant-bounded surface: cross-tenant ROUTING, but every query MUST name
   // a tenant — no platform aggregate. Spell that out once here (the host surfaces it per connection) so the
   // model passes tenantId up front instead of discovering it via a tool error. A delegated admin who is
@@ -231,8 +231,18 @@ function buildInstructions(ga: boolean, delegated: boolean, managedTenants: stri
         (homeTenantId ? ` If you are a member of your own home tenant (${homeTenantId}), you may query it by naming it too.` : '') +
         ' Call list_tenants to resolve these IDs to tenant display names (domainName).'
       : 'Scope: all queries are automatically limited to your tenant.';
+  // Role-aware headline: everyone below a real Global Admin keeps the exact READ-ONLY
+  // contract (and wording) this server has always advertised. A strict GA additionally
+  // holds the tenant-config write tools — say so once, with the safety model, so the
+  // model reaches for update/revert instead of assuming writes are impossible.
+  const headline = strictGa
+    ? 'Autopilot-Monitor is a telemetry server for Windows Autopilot enrollment sessions. All investigation ' +
+      'tools are read-only; as a Global Admin you additionally have tenant-configuration write tools ' +
+      '(update_tenant_config, revert_tenant_config). Every config write is snapshotted first and verified ' +
+      'after — use list_tenant_config_backups + revert_tenant_config to roll back.'
+    : 'Autopilot-Monitor is a READ-ONLY telemetry server for Windows Autopilot enrollment sessions.';
   return [
-    'Autopilot-Monitor is a READ-ONLY telemetry server for Windows Autopilot enrollment sessions.',
+    headline,
     '',
     'Investigating one session: call get_session_summary FIRST (status, filtered timeline, stats, rule analysis in one call), then drill in.',
     ...(docsIndex
@@ -257,7 +267,7 @@ function buildInstructions(ga: boolean, delegated: boolean, managedTenants: stri
 function createMcpServer(ga: boolean, strictGa: boolean, delegated: boolean, managedTenants: string[], homeTenantId?: string): McpServer {
   const s = new McpServer(
     { name: 'Autopilot-Monitor', version: SERVER_VERSION },
-    { instructions: buildInstructions(ga, delegated, managedTenants, homeTenantId) },
+    { instructions: buildInstructions(ga, strictGa, delegated, managedTenants, homeTenantId) },
   );
   registerTools(s, knowledgeBase, eventTypeIndex, DOCS, ga, strictGa, delegated);
   registerResources(s);

--- a/src/McpServer/autopilot-monitor-mcp/src/tools.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/tools.ts
@@ -9,11 +9,14 @@ import type { DocsSearchBundle } from './search-provider.js';
  * Registers the tool catalog for a single request, tailored to the caller's role.
  *
  * `ga` here means platform SCOPE (Global Admin OR read-only Global Reader) — the broad gate for
- * cross-tenant read tools. `strictGa` is true ONLY for a real Global Admin and gates the few raw
- * tools whose backend endpoints stay GlobalAdminOnly (list_tables / query_table / query_backend_logs)
- * because they can dump secret-bearing tables that the GlobalReader config redaction would otherwise
- * hide. When `ga` is false (normal tenant user) no platform tool is registered at all — they never
- * appear in tools/list — and the remaining tools' descriptions carry no cross-tenant wording.
+ * cross-tenant read tools. `strictGa` is true ONLY for a real Global Admin and gates two groups whose
+ * backend endpoints stay GlobalAdminOnly: the raw tools (list_tables / query_table /
+ * query_backend_logs — they can dump secret-bearing tables that the GlobalReader config redaction
+ * would otherwise hide) and the tenant-config write surface (get_tenant_config /
+ * update_tenant_config / list_tenant_config_backups / revert_tenant_config — the server's only
+ * mutating tools; every write is snapshot-backed and verified server-side). When `ga` is false
+ * (normal tenant user) no platform tool is registered at all — they never appear in tools/list —
+ * and the remaining tools' descriptions carry no cross-tenant wording.
  *
  * `delegated` marks a delegated (scoped-global / MSP) caller — one with NO platform role (so `ga` is
  * false) but a non-empty managed tenant set. Such a caller routes cross-tenant (to /api/global/*) but is

--- a/src/McpServer/autopilot-monitor-mcp/src/tools/admin.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/tools/admin.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { apiFetch, buildQuery, enforceDelegatedTenant, enforceDelegatedTenantForPage, followNextLink, getCallerUpnDomain, getDelegatedTenantIds, getHomeTenantId, pickGlobalOrTenantPath, scanUntilMatch } from '../client.js';
 import { withToolTelemetry } from '../telemetry.js';
 import { getResourceContent, assertKnownEventType } from '../resource-catalog.js';
-import { READ_ONLY, READ_ONLY_OPEN, MAX_RESULT_SIZE_CHARS, toolResultText, SessionIdSchema, tenantIdDescription } from './shared.js';
+import { READ_ONLY, READ_ONLY_OPEN, MUTATING, MAX_RESULT_SIZE_CHARS, toolResultText, SessionIdSchema, TenantGuidSchema, tenantIdDescription } from './shared.js';
 import { toolError } from './error-handler.js';
 
 /**
@@ -1038,6 +1038,144 @@ export function registerAdminTools(server: McpServer, ga: boolean, strictGa: boo
         return toolResultText(data, MAX_RESULT_SIZE_CHARS.events);
       } catch (error: unknown) {
         return toolError('query_backend_logs', args, error);
+      }
+    })
+  );
+
+  // ── Tenant-config write surface (transactional) ───────────────────────
+  // Security note: all four tools are strictGa (real Global Admin only) — the backend
+  // routes (PATCH config/{tenantId}/fields, GET .../backups, POST .../revert) are
+  // GlobalAdminOnly to match. get_tenant_config is read-only but ALSO strictGa: its
+  // full-config view (even redacted) exposes operational settings no Reader needs.
+  // The write flow is transactional server-side: fail-closed pre-write snapshot →
+  // ETag-conditional write → re-read → verify that EXACTLY the intended fields
+  // changed → automatic rollback on drift. Every change is revertible.
+
+  if (strictGa) server.registerTool(
+    'get_tenant_config',
+    {
+      title: 'Get Tenant Configuration',
+      description:
+        'Read a tenant\'s full configuration (all ~90 settings). Global Admin only. ' +
+        'Secrets (webhook URLs, SAS URLs, custom headers) are ALWAYS redacted to "***REDACTED***" in this view — ' +
+        'never copy a redacted placeholder into update_tenant_config; provide the real value or leave the field out. ' +
+        'Use this before update_tenant_config to see current values and exact field names.',
+      inputSchema: {
+        tenantId: TenantGuidSchema.describe('Tenant ID (GUID) whose configuration to read.'),
+      },
+      annotations: READ_ONLY,
+    },
+    async (args) => withToolTelemetry('get_tenant_config', async () => {
+      try {
+        // view=redacted is load-bearing: without it the backend serves a GA the
+        // clear-text secrets, which must never enter model context (pinned by
+        // security-guards tests).
+        const data = await apiFetch(`/api/config/${encodeURIComponent(args.tenantId)}?view=redacted`);
+        return toolResultText(data, MAX_RESULT_SIZE_CHARS.small);
+      } catch (error: unknown) {
+        return toolError('get_tenant_config', args, error);
+      }
+    })
+  );
+
+  if (strictGa) server.registerTool(
+    'update_tenant_config',
+    {
+      title: 'Update Tenant Configuration',
+      description:
+        'Change specific fields of a tenant\'s configuration — transactional and verified. Global Admin only. ' +
+        'Pass ONLY the fields to change (camelCase or PascalCase); omitted fields stay untouched; an explicit JSON ' +
+        'null clears a nullable field. The backend snapshots the row first (fail-closed), writes conditionally, ' +
+        're-reads, and verifies that exactly the intended fields changed — on any drift it rolls back automatically. ' +
+        'Not writable here (400 with the field name): identity (tenantId/domainName), plan/trial fields ' +
+        '(dedicated endpoints), homedAppClientId / auth provenance / onboarded* (system-owned), lastUpdated/updatedBy ' +
+        '(stamped server-side). Response: applied field names, a masked diff, and the backupId for ' +
+        'revert_tenant_config. Never send "***REDACTED***" values.',
+      inputSchema: {
+        tenantId: TenantGuidSchema.describe('Tenant ID (GUID) whose configuration to change.'),
+        fields: z.record(z.unknown())
+          .describe('Object of fieldName → newValue for ONLY the fields to change (e.g. {"dataRetentionDays": 90}). ' +
+                    'Use get_tenant_config for current values and exact field names.'),
+        reason: z.string().min(1)
+          .describe('REQUIRED: why this change is being made. Stored with the backup snapshot and the audit log entry.'),
+      },
+      annotations: MUTATING,
+    },
+    async (args) => withToolTelemetry('update_tenant_config', async () => {
+      try {
+        const data = await apiFetch(`/api/config/${encodeURIComponent(args.tenantId)}/fields`, {
+          method: 'PATCH',
+          body: JSON.stringify({ fields: args.fields, reason: args.reason }),
+        });
+        return toolResultText(data, MAX_RESULT_SIZE_CHARS.small);
+      } catch (error: unknown) {
+        return toolError('update_tenant_config', args, error);
+      }
+    })
+  );
+
+  if (strictGa) server.registerTool(
+    'list_tenant_config_backups',
+    {
+      title: 'List Tenant Config Backups',
+      description:
+        'List a tenant\'s pre-write configuration snapshots, newest first. Global Admin only. ' +
+        'Every config write (portal, plan changes, MCP patches) snapshots the row beforehand; the newest 2 are kept. ' +
+        'Returns metadata only — backupId, when, who, source, reason, and a masked field diff (never raw values). ' +
+        'Use a backupId with revert_tenant_config to roll a tenant back.',
+      inputSchema: {
+        tenantId: TenantGuidSchema.describe('Tenant ID (GUID) whose backups to list.'),
+        max: z.coerce.number().int().min(1).max(25).optional()
+          .describe('Maximum snapshots to return (default 25 — pruning keeps only the newest 2 anyway).'),
+      },
+      annotations: READ_ONLY,
+    },
+    async (args) => withToolTelemetry('list_tenant_config_backups', async () => {
+      try {
+        const query = args.max != null ? `?max=${encodeURIComponent(String(args.max))}` : '';
+        const data = await apiFetch(`/api/config/${encodeURIComponent(args.tenantId)}/backups${query}`);
+        return toolResultText(data, MAX_RESULT_SIZE_CHARS.small);
+      } catch (error: unknown) {
+        return toolError('list_tenant_config_backups', args, error);
+      }
+    })
+  );
+
+  if (strictGa) server.registerTool(
+    'revert_tenant_config',
+    {
+      title: 'Revert Tenant Configuration',
+      description:
+        'Restore a tenant\'s configuration from a pre-write snapshot (latest by default). Global Admin only. ' +
+        'The revert snapshots the CURRENT state first, so a revert is itself revertible. Protected fields ' +
+        '(plan/trial, homedAppClientId, auth provenance, onboarded*) keep their CURRENT values unless ' +
+        'includeProtectedFields is explicitly true — time-traveling those via an old snapshot is almost never ' +
+        'intended. Same transactional verify-and-rollback machinery as update_tenant_config.',
+      inputSchema: {
+        tenantId: TenantGuidSchema.describe('Tenant ID (GUID) whose configuration to revert.'),
+        backupId: z.string().optional()
+          .describe('Snapshot to restore (from list_tenant_config_backups). Omit for the most recent snapshot.'),
+        includeProtectedFields: z.boolean().optional()
+          .describe('DANGEROUS, default false: also restore plan/trial, homedAppClientId and auth-provenance fields ' +
+                    'from the snapshot. Only set when the snapshot\'s values for those are explicitly wanted.'),
+        reason: z.string().min(1)
+          .describe('REQUIRED: why this revert is being made. Stored with the new backup and the audit log entry.'),
+      },
+      annotations: MUTATING,
+    },
+    async (args) => withToolTelemetry('revert_tenant_config', async () => {
+      try {
+        const data = await apiFetch(`/api/config/${encodeURIComponent(args.tenantId)}/revert`, {
+          method: 'POST',
+          body: JSON.stringify({
+            backupId: args.backupId,
+            includeProtectedFields: args.includeProtectedFields ?? false,
+            reason: args.reason,
+          }),
+        });
+        return toolResultText(data, MAX_RESULT_SIZE_CHARS.small);
+      } catch (error: unknown) {
+        return toolError('revert_tenant_config', args, error);
       }
     })
   );

--- a/src/McpServer/autopilot-monitor-mcp/src/tools/shared.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/tools/shared.ts
@@ -65,11 +65,39 @@ export function tenantIdDescription(ga: boolean, delegated: boolean, gaText: str
   return ga ? gaText : tenantText;
 }
 
+/**
+ * Zod validator for tenant IDs interpolated into backend URL paths
+ * (`/api/config/{tenantId}/...`). Same path-traversal rationale as
+ * SessionIdSchema: WHATWG-URL normalization collapses `..` segments, so an
+ * unvalidated value could silently route to a different endpoint.
+ */
+export const TenantGuidSchema = z
+  .string()
+  .regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    'tenantId must be a GUID (e.g. "e259c121-1234-4abc-9def-0123456789ab")',
+  );
+
 /** Read-only query tool — no side effects, idempotent, closed-world (our backend only). */
 export const READ_ONLY: ToolAnnotations = {
   readOnlyHint: true,
   destructiveHint: false,
   idempotentHint: true,
+  openWorldHint: false,
+};
+
+/**
+ * Config-mutating tool — writes tenant configuration via the backend's
+ * transactional endpoints (PATCH fields / POST revert). destructiveHint is
+ * true because the write overwrites prior values (clients may ask the user
+ * to confirm); NOT idempotent — repeating a revert after further changes
+ * restores a different state. Every write is preceded by a fail-closed
+ * snapshot server-side, so the operation is always revertible.
+ */
+export const MUTATING: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
   openWorldHint: false,
 };
 

--- a/src/Shared/AutopilotMonitor.Shared/Constants.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Constants.cs
@@ -861,6 +861,15 @@ namespace AutopilotMonitor.Shared
         /// </summary>
         public const string RedactedSecretPlaceholder = "***REDACTED***";
 
+        /// <summary>
+        /// Snapshots kept per partition in <see cref="TableNames.ConfigurationBackups"/>.
+        /// Two, not one: a revert first snapshots the current state itself, and a single
+        /// interleaved portal save would otherwise evict the state still needed — two slots
+        /// cover "undo the last two real changes". Noise-only and no-op saves never snapshot,
+        /// so both slots always hold genuine change states.
+        /// </summary>
+        public const int ConfigBackupKeepCount = 2;
+
         // -----------------------------------------------------------------------
         // Audit logging
         // -----------------------------------------------------------------------
@@ -1079,6 +1088,17 @@ namespace AutopilotMonitor.Shared
             // Daily cleanup function evicts entries older than the TTL.
             public const string ScriptNameCache = "ScriptNameCache";
 
+            // Pre-write snapshots of the two single-row config entities, taken by
+            // TableConfigRepository immediately before an overwriting save so any config
+            // change can be reverted. NOT a generic mechanism — only TenantConfiguration
+            // and AdminConfiguration share the single-row-overwrite pattern this protects.
+            //   - PartitionKey = normalized tenantId (tenant config)
+            //                    or AdminConfiguration's "GlobalConfig" (admin config)
+            //   - RowKey       = "{DateTime.MaxValue.Ticks - nowTicks:D19}_{8-char guid}" (newest first)
+            // Pruned to the newest ConfigBackupKeepCount per partition on every write;
+            // the tenant partition is wiped by the offboarding cascade.
+            public const string ConfigurationBackups = "ConfigurationBackups";
+
             // Critical-table backup/restore job tracking (plan §PR1). Single-partition
             // PK="BackupJobs", RK={jobId}. Persists per-job state machine
             // (Queued / Running / Completed / Failed / Skipped / BlockedTerminal),
@@ -1153,6 +1173,7 @@ namespace AutopilotMonitor.Shared
                 TenantOffboardingCustomsArchive,
                 ScriptNameCache,
                 BackupJobs,
+                ConfigurationBackups,
             };
         }
 
@@ -1333,6 +1354,7 @@ namespace AutopilotMonitor.Shared
             {
                 TableNames.AdminConfiguration,
                 TableNames.AnalyzeRules,
+                TableNames.ConfigurationBackups,
                 TableNames.DelegatedAdmins,
                 TableNames.Feedback,
                 TableNames.GatherRules,

--- a/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigBackupRepository.cs
+++ b/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigBackupRepository.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Shared.DataAccess
+{
+    /// <summary>
+    /// Pre-write snapshots of the two single-row config entities (see
+    /// <see cref="ConfigBackupEntry"/>). Written by the config repository's save hook
+    /// (fail-soft) and by the transactional patch/revert flow (fail-closed), pruned to
+    /// the newest few per partition. Reads back newest-first via the reverse-ticks RowKey.
+    /// </summary>
+    public interface IConfigBackupRepository
+    {
+        Task UpsertAsync(ConfigBackupEntry entry, CancellationToken ct = default);
+
+        /// <summary>Newest-first snapshots for one partition (tenantId or "GlobalConfig").</summary>
+        Task<List<ConfigBackupEntry>> ListByPartitionAsync(string partitionKey, int max = 25, CancellationToken ct = default);
+
+        /// <summary>Point lookup by backupId (= RowKey); null when absent.</summary>
+        Task<ConfigBackupEntry?> TryGetAsync(string partitionKey, string backupId, CancellationToken ct = default);
+
+        /// <summary>Deletes every snapshot beyond the newest <paramref name="keep"/>; returns rows removed.</summary>
+        Task<int> PruneAsync(string partitionKey, int keep, CancellationToken ct = default);
+    }
+}

--- a/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigRepository.cs
+++ b/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigRepository.cs
@@ -24,6 +24,22 @@ namespace AutopilotMonitor.Shared.DataAccess
         /// </summary>
         Task<bool> SaveTenantConfigurationAsync(TenantConfiguration config, string? backupSource, string? backupReason);
 
+        /// <summary>
+        /// Point read that also surfaces the row's ETag (as an opaque string, keeping this
+        /// interface storage-agnostic) for use with <see cref="TryReplaceTenantConfigurationAsync"/>.
+        /// Null when the tenant has no configuration row. Storage errors throw (fail-loud —
+        /// this is the transactional read path, not a fail-soft helper).
+        /// </summary>
+        Task<(TenantConfiguration Config, string ETag)?> GetTenantConfigurationWithEtagAsync(string tenantId);
+
+        /// <summary>
+        /// Conditional full replace (If-Match). Returns false ONLY when the precondition failed
+        /// (someone else wrote the row since the ETag was read — the caller re-reads and retries);
+        /// any other storage failure throws. Deliberately does NOT run the pre-write backup hook:
+        /// the transactional caller snapshots explicitly and fail-CLOSED before invoking this.
+        /// </summary>
+        Task<bool> TryReplaceTenantConfigurationAsync(TenantConfiguration config, string etag);
+
         Task<List<TenantConfiguration>> GetAllTenantConfigurationsAsync();
 
         /// <summary>

--- a/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigRepository.cs
+++ b/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigRepository.cs
@@ -15,6 +15,15 @@ namespace AutopilotMonitor.Shared.DataAccess
         // --- Tenant Configuration ---
         Task<TenantConfiguration?> GetTenantConfigurationAsync(string tenantId);
         Task<bool> SaveTenantConfigurationAsync(TenantConfiguration config);
+
+        /// <summary>
+        /// Same unconditional replace as <see cref="SaveTenantConfigurationAsync(TenantConfiguration)"/>,
+        /// but tags the pre-write backup snapshot with the write path and intent. A separate
+        /// overload — NOT optional parameters — because Moq expression trees cannot omit
+        /// optional arguments (CS0854) and the 1-arg signature is mocked all over the test suite.
+        /// </summary>
+        Task<bool> SaveTenantConfigurationAsync(TenantConfiguration config, string? backupSource, string? backupReason);
+
         Task<List<TenantConfiguration>> GetAllTenantConfigurationsAsync();
 
         /// <summary>

--- a/src/Shared/AutopilotMonitor.Shared/Models/Config/ConfigBackupEntry.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/Config/ConfigBackupEntry.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace AutopilotMonitor.Shared.Models
+{
+    /// <summary>
+    /// One pre-write snapshot of a single-row config entity (TenantConfiguration or
+    /// AdminConfiguration), taken immediately before the row is overwritten so the
+    /// change can be reverted. Stored in <c>Constants.TableNames.ConfigurationBackups</c>.
+    /// <para>
+    /// PartitionKey = normalized tenantId (tenant config) or AdminConfiguration's
+    /// "GlobalConfig" partition (admin config). RowKey = reverse-ticks + short guid,
+    /// so a partition scan returns newest-first. The RowKey doubles as the public
+    /// backupId in API responses.
+    /// </para>
+    /// <para>
+    /// <see cref="EntityJson"/> holds the raw stored row (every table property except
+    /// odata.etag/Timestamp) — full fidelity for restore, independent of model
+    /// refactors. It contains secrets in clear text and must NEVER be returned by
+    /// list endpoints; <see cref="DiffJson"/> is the masked, advisory summary that is
+    /// safe to surface.
+    /// </para>
+    /// </summary>
+    public class ConfigBackupEntry
+    {
+        public string PartitionKey { get; set; } = string.Empty;
+        public string RowKey { get; set; } = string.Empty;
+
+        /// <summary>Normalized tenantId, or "GlobalConfig" for admin-config snapshots.</summary>
+        public string TenantId { get; set; } = string.Empty;
+
+        /// <summary>Raw stored row as JSON (property name → value), excluding odata.etag/Timestamp.</summary>
+        public string EntityJson { get; set; } = string.Empty;
+
+        /// <summary>Identity about to overwrite the row (UpdatedBy of the incoming save, or "system").</summary>
+        public string ChangedBy { get; set; } = "system";
+
+        /// <summary>
+        /// Write path that triggered the snapshot: portal-put | plan | auth | app-homing |
+        /// offboard | admin-config | mcp-patch | mcp-revert | revert | unknown.
+        /// </summary>
+        public string Source { get; set; } = "unknown";
+
+        /// <summary>Optional caller-provided intent (MCP tools require one).</summary>
+        public string? Reason { get; set; }
+
+        /// <summary>Masked "old → new" summary of the incoming change (ConfigDiffHelper output). Advisory only.</summary>
+        public string? DiffJson { get; set; }
+
+        public DateTime BackupTakenAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

GA-only MCP surface to reconfigure customer tenants safely, backed by a platform-wide config backup net.

- **PR1 — Backup net** (`3e2a007d`): new `ConfigurationBackups` table (PK=tenantId or `GlobalConfig`, RK=reverse-ticks+guid). Every overwriting save of TenantConfiguration/AdminConfiguration snapshots the raw stored row first via a hook in `TableConfigRepository` (the single choke point). Fail-soft on legacy paths, noise-filtered (LastAuthClientId flips do not snapshot), pruned to the newest 2 per partition. Registered in `TableNames.All`, `CriticalBackupTables.All`, the offboarding cascade (`TenantPartitionTables`) and the marker-cleanup tombstone sweep.
- **PR2 — Transactional endpoints** (`abf78a5e`): `PATCH config/{tenantId}/fields`, `GET config/{tenantId}/backups` (metadata + masked diff only, never raw EntityJson), `POST config/{tenantId}/revert` — all GlobalAdminOnly + RouteParam in the policy catalog. `TenantConfigPatchService` implements the verified write: fresh ETag read -> field gate (plan/trial, HomedAppClientId, auth provenance, identity are denied with the field name) -> patch onto a clone -> shared validation (extracted from the PUT into `TenantConfigValidation`) -> fail-CLOSED backup -> CAS replace -> fresh re-read -> verify that EXACTLY the intended fields changed -> automatic ETag-conditional rollback on drift (catches Store/Map serialization asymmetry). Revert restores latest/named snapshot, preserves protected fields unless `includeProtectedFields`, and snapshots the current state first (a revert is itself revertible). `GET config/{tenantId}` gains `?view=redacted`.
- **PR3 — MCP tools** (`7a9c1ea9`): first mutating tools on the MCP server, strictGa only: `get_tenant_config` (always `?view=redacted` — secrets never reach model context, test-pinned), `update_tenant_config` (required `reason`, lands in backup + audit), `list_tenant_config_backups`, `revert_tenant_config`. New `MUTATING` annotation + `TenantGuidSchema`; role-aware instructions headline (non-GA keeps the exact READ-ONLY wording); catalog snapshot test extends `GA_FULL` + new `CONFIG_WRITE_GA_STRICT` difference list.

Phase 2 (tenant admins / delegated MSP writes) is prepared but NOT active: caller-tier field deny-lists exist with tests; rollout later is a policy-catalog flip + MCP gate widening (DelegatedReader must stay excluded).

## Test plan

- Backend: full xUnit suite 3848/3848 green (new: ConfigBackupHookTests, ConfigBackupRepositoryTests, TenantConfigPatchServiceTests incl. CAS-race/drift-rollback/rehydration-roundtrip, policy + redaction pins)
- MCP: vitest 464/464 green (new: config-write-tools.test.ts), `tsc --noEmit` clean
- Post-merge deploy order is mandatory: **backend first, then MCP redeploy** (tools call the new routes). First live test only against our own test tenant: get -> update (dataRetentionDays) -> list_backups -> revert; then a portal save must produce a `portal-put` backup row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)